### PR TITLE
Refactor: Isolate provider configs to provider packages

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -6,34 +6,55 @@ import (
 	"github.com/nebari-dev/nebari-infrastructure-core/pkg/config"
 )
 
-// Provider defines the interface that all cloud providers must implement
+// Provider defines the interface that all cloud providers must implement.
+//
+// This interface establishes the abstraction boundary between CLI commands and
+// provider implementations. CLI commands depend only on this interface, never on
+// concrete provider types, enabling new providers to be added without modifying
+// CLI code (Open/Closed Principle).
 type Provider interface {
-	// Name returns the provider name (aws, gcp, azure, local)
+	// Name returns the short provider identifier used in CLI output, logging,
+	// and OpenTelemetry span attributes (e.g., "aws", "gcp", "azure", "local").
 	Name() string
 
-	// ConfigKey returns the YAML key for this provider's configuration
-	// e.g., "amazon_web_services", "google_cloud_platform", "azure", "local"
+	// ConfigKey returns the YAML key used for this provider's configuration block.
+	// This allows providers to extract their own config from NebariConfig.ProviderConfig
+	// without the config package needing to know about provider-specific types.
+	// Examples: "amazon_web_services", "google_cloud_platform", "azure", "local"
 	ConfigKey() string
 
-	// Validate validates the configuration before deployment
+	// Validate checks that the configuration is valid before any infrastructure
+	// operations. This includes verifying required fields, validating formats,
+	// and checking cloud-specific constraints (e.g., valid regions, instance types).
 	Validate(ctx context.Context, config *config.NebariConfig) error
 
-	// Deploy deploys infrastructure based on the provided configuration
-	// This is a high-level method that orchestrates resource creation
+	// Deploy creates or updates infrastructure to match the desired configuration.
+	// Backed by OpenTofu, this operation is idempotent - running Deploy multiple
+	// times with the same config results in the same infrastructure state.
+	// Use --dry-run flag to preview changes without applying them (runs tofu plan).
 	Deploy(ctx context.Context, config *config.NebariConfig) error
 
-	// Reconcile compares desired config against actual state and reconciles differences
-	// This is the core stateless reconciliation method
+	// Reconcile compares desired config against actual state and reconciles differences.
+	// Deprecated: This method is redundant with OpenTofu - Deploy already performs
+	// reconciliation via tofu apply. See https://github.com/nebari-dev/nebari-infrastructure-core/issues/44
 	Reconcile(ctx context.Context, config *config.NebariConfig) error
 
-	// Destroy tears down all infrastructure in reverse order
+	// Destroy tears down all infrastructure resources in the correct order,
+	// respecting dependencies (e.g., node groups before cluster, cluster before VPC).
+	// Backed by OpenTofu's tofu destroy command.
 	Destroy(ctx context.Context, config *config.NebariConfig) error
 
-	// GetKubeconfig generates a kubeconfig file for accessing the Kubernetes cluster
+	// GetKubeconfig generates a kubeconfig file for authenticating with the
+	// Kubernetes cluster. The returned bytes can be written to a file or used
+	// directly with Kubernetes client libraries.
 	GetKubeconfig(ctx context.Context, config *config.NebariConfig) ([]byte, error)
 
-	// Summary returns key-value pairs describing the configuration for display purposes.
-	// Used by CLI commands to show provider-specific details without knowing provider internals.
+	// Summary returns key-value pairs describing provider-specific configuration
+	// for display purposes. This allows CLI commands to show details like region
+	// or project in confirmation prompts without importing provider packages.
+	// Used in destructive operations to help users confirm they're targeting
+	// the correct infrastructure (e.g., distinguishing clusters with the same
+	// name in different regions).
 	Summary(config *config.NebariConfig) map[string]string
 }
 


### PR DESCRIPTION
## Summary

This PR refactors provider-specific configurations out of the core config package into their respective provider packages, establishing clear software boundaries.

### Changes

- Remove explicit provider fields from `NebariConfig` (AmazonWebServices, GoogleCloudPlatform, Azure, Local)
- Add `ProviderConfig` map with `yaml:",inline"` to capture provider-specific configs dynamically
- Add `ConfigKey()` method to `Provider` interface for YAML key discovery
- Add `Summary()` method to `Provider` interface for display purposes
- Update all providers to extract their own configs via direct map access
- Remove provider-specific imports from CLI commands (except main.go for registration)
- Add unit tests for config package

## Why This Matters

### The Problem with Leaky Abstractions

When the config package knows about specific providers, we create tight coupling that:
- **Violates the Open/Closed Principle**: Adding a new provider requires modifying NebariConfig
- **Creates import cycles risk**: The config package shouldn't depend on provider implementations
- **Reduces testability**: Tests need to understand provider-specific types
- **Increases cognitive load**: Developers must understand all providers to modify config parsing

### The Dependency Rule

As described in [Clean Architecture](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html), dependencies should point inward:
- Core abstractions (config, provider interface) should not know about implementations
- Implementations (AWS, GCP, Azure) depend on abstractions, not vice versa

### Ports and Adapters

This refactoring aligns with the [Ports and Adapters (Hexagonal) Architecture](https://alistair.cockburn.us/hexagonal-architecture/):
- `pkg/config` is the core domain - provider-agnostic
- `pkg/provider/*` are adapters - they understand provider specifics
- The CLI is an adapter - it orchestrates without knowing implementation details

### Practical Benefits

1. **Adding new providers**: Just implement the interface and register - no core changes needed
2. **Testing**: Mock the Provider interface without importing provider packages
3. **Compilation**: Changes to AWS provider don't require recompiling GCP code
4. **Onboarding**: New developers can understand one provider without learning all of them

## References

- [The Clean Architecture - Uncle Bob](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html)
- [Hexagonal Architecture - Alistair Cockburn](https://alistair.cockburn.us/hexagonal-architecture/)
- [Package Oriented Design - William Kennedy](https://www.ardanlabs.com/blog/2017/02/package-oriented-design.html)
- [SOLID Principles - Uncle Bob](https://blog.cleancoder.com/uncle-bob/2020/10/18/Solid-Relevance.html)

## Test plan

- [x] All existing tests pass
- [x] New unit tests for `IsValidProvider()` and `ProviderConfig` map access
- [x] Linting passes
- [x] No provider-specific imports in CLI commands (except main.go registration)
- [x] No cross-package imports between provider implementations

Closes #39