### PR TITLE
Fix Provider interface documentation to match code

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -64,7 +64,7 @@ nebari-infrastructure-core/
 
 | File | Purpose |
 |------|---------|
-| `provider.go` | Defines `Provider` interface with Validate(), Deploy(), Reconcile(), Destroy(), GetKubeconfig() |
+| `provider.go` | Defines `Provider` interface with Name(), ConfigKey(), Validate(), Deploy(), Reconcile(), Destroy(), GetKubeconfig(), Summary() |
 | `registry.go` | Thread-safe provider registry with registration and lookup |
 
 ### AWS Provider (pkg/provider/aws/) - **Fully Implemented**

--- a/WALKTHROUGH.md
+++ b/WALKTHROUGH.md
@@ -56,15 +56,17 @@ Files organized by **resource** (vpc, eks, nodegroups), not by operation. Each r
 ```go
 type Provider interface {
     Name() string
+    ConfigKey() string
     Validate(ctx context.Context, config *config.NebariConfig) error
     Deploy(ctx context.Context, config *config.NebariConfig) error
-    Reconcile(ctx context.Context, config *config.NebariConfig) error
+    Reconcile(ctx context.Context, config *config.NebariConfig) error  // Deprecated - see issue #44
     Destroy(ctx context.Context, config *config.NebariConfig) error
-    GetKubeconfig(ctx context.Context, clusterName string) ([]byte, error)
+    GetKubeconfig(ctx context.Context, config *config.NebariConfig) ([]byte, error)
+    Summary(config *config.NebariConfig) map[string]string
 }
 ```
 
-`Deploy()` delegates to `Reconcile()`. The distinction exists for dry-run handling and future pre-flight checks.
+`Deploy()` is idempotent - running it multiple times with the same config produces the same result. Use `--dry-run` to preview changes.
 
 ---
 


### PR DESCRIPTION
## Summary

Updates WALKTHROUGH.md and ARCHITECTURE.md to accurately reflect the current Provider interface.

## Changes

- Add missing `ConfigKey()` and `Summary()` methods to interface definition
- Fix `GetKubeconfig` signature: takes `config *config.NebariConfig`, not `clusterName string`
- Mark `Reconcile` as deprecated with reference to issue #44
- Update `Deploy` description to focus on idempotency rather than delegation to Reconcile

## Test plan

- [x] Documentation-only change
- [x] Verified interface matches `pkg/provider/provider.go`