### PR TITLE
Add minimal PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug Report
+about: Report a bug
+labels: bug
+---
+
+## Description
+
+<!-- What happened? What did you expect to happen? -->
+
+## Steps to Reproduce
+
+<!-- If applicable, how can we reproduce this? -->
+
+## Error Output
+
+<!-- Paste any error messages or relevant CLI output -->
+
+## Environment
+
+<!-- NIC version, OS, cloud provider, etc. (if relevant) -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,13 @@
+---
+name: Feature Request
+about: Suggest an improvement or new feature
+labels: enhancement
+---
+
+## Description
+
+<!-- What would you like to see added or changed? -->
+
+## Use Case
+
+<!-- Why is this needed? What problem does it solve? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Closes
+
+<!-- Link to issue(s) this PR addresses, e.g., Closes #123 -->
+
+## Description
+
+<!-- Brief description of what this PR does -->
+
+## How to Test
+
+<!-- Steps to verify the changes work correctly -->


### PR DESCRIPTION
## Closes

Replaces verbose org-level templates with minimal, project-specific ones.

## Description

Adds simple PR and issue templates:
- **PR template**: Closes #, Description, How to Test
- **Bug report**: Description, Steps to Reproduce, Error Output, Environment
- **Feature request**: Description, Use Case
- Blank issues enabled

## How to Test

Create a new issue or PR and verify the templates appear.