### PR TITLE
Enable cluster creator admin permissions in EKS module

### DIFF
--- a/pkg/provider/aws/templates/main.tf
+++ b/pkg/provider/aws/templates/main.tf
@@ -27,7 +27,7 @@ module "eks_cluster" {
   existing_cluster_iam_role_arn            = var.existing_cluster_iam_role_arn
   existing_node_iam_role_arn               = var.existing_node_iam_role_arn
   iam_role_permissions_boundary            = var.iam_role_permissions_boundary
-  enable_cluster_creator_admin_permissions = false
+  enable_cluster_creator_admin_permissions = true
   node_groups                              = var.node_groups
   efs_enabled                              = var.efs_enabled
   efs_performance_mode                     = var.efs_performance_mode


### PR DESCRIPTION
## Closes

<!-- Link to issue(s) this PR addresses, e.g., Closes #123 -->

## Description

This PR makes sure to set `enable_cluster_creator_admin_permissions=true` so the IAM entity that deploys the cluster can run `kubectl` commands on it.

## How to Test

<!-- Steps to verify the changes work correctly -->
