### PR TITLE
Implement credential validation in AWS provider

### DIFF
--- a/cmd/nic/validate.go
+++ b/cmd/nic/validate.go
@@ -10,24 +10,30 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/nebari-dev/nebari-infrastructure-core/pkg/config"
+	"github.com/nebari-dev/nebari-infrastructure-core/pkg/provider"
 	"github.com/nebari-dev/nebari-infrastructure-core/pkg/registry"
 )
 
 var (
 	validateConfigFile string
+	validateCreds      bool
 
 	validateCmd = &cobra.Command{
 		Use:   "validate",
 		Short: "Validate configuration file",
 		Long: `Validate the nebari-config.yaml file without deploying any infrastructure.
 This command checks that the configuration file is properly formatted and contains
-all required fields.`,
+all required fields.
+
+Use --validate-creds to perform thorough credential validation including permission
+checks (currently supported for AWS only).`,
 		RunE: runValidate,
 	}
 )
 
 func init() {
 	validateCmd.Flags().StringVarP(&validateConfigFile, "file", "f", "", "Path to nebari-config.yaml file (auto-discovered if omitted)")
+	validateCmd.Flags().BoolVar(&validateCreds, "validate-creds", false, "Perform thorough credential validation (AWS only)")
 }
 
 func runValidate(cmd *cobra.Command, args []string) error {
@@ -45,7 +51,10 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	ctx, span := tracer.Start(ctx, "cmd.validate")
 	defer span.End()
 
-	span.SetAttributes(attribute.String("config.file", validateConfigFile))
+	span.SetAttributes(
+		attribute.String("config.file", validateConfigFile),
+		attribute.Bool("validate_creds", validateCreds),
+	)
 
 	slog.Info("Validating configuration", "config_file", validateConfigFile)
 
@@ -72,6 +81,31 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	fmt.Printf("✓ Configuration file is valid\n")
 	fmt.Printf("  Provider: %s\n", cfg.Cluster.ProviderName())
 	fmt.Printf("  Project: %s\n", cfg.ProjectName)
+
+	// Perform thorough credential validation if requested.
+	if validateCreds {
+		providerName := cfg.Cluster.ProviderName()
+		p, err := reg.ClusterProviders.Get(ctx, providerName)
+		if err != nil {
+			span.RecordError(err)
+			slog.Error("Provider not available", "error", err, "provider", providerName)
+			return err
+		}
+
+		cv, ok := p.(provider.CredentialValidator)
+		if !ok {
+			fmt.Printf("Note: The %s provider does not support --validate-creds\n", providerName)
+			return nil
+		}
+
+		slog.Info("Performing credential validation", "provider", providerName)
+		if err := cv.ValidateCredentials(ctx, cfg.ProjectName, cfg.Cluster); err != nil {
+			span.RecordError(err)
+			slog.Error("Credential validation failed", "error", err, "provider", providerName)
+			return err
+		}
+		fmt.Printf("✓ Credentials are valid with required permissions\n")
+	}
 
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.31.20
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.286.0
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.19
+	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.11
+	github.com/aws/aws-sdk-go-v2/service/iam v1.53.8
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.95.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.40.2
 	github.com/aws/smithy-go v1.25.0
@@ -24,6 +26,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.38.0
 	go.opentelemetry.io/otel/trace v1.38.0
 	golang.org/x/crypto v0.48.0
+	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.19.4
 	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0
@@ -53,7 +56,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.17 // indirect
-	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.11 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17 // indirect
@@ -169,7 +171,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.34.2 // indirect
 	k8s.io/apiserver v0.34.2 // indirect
 	k8s.io/cli-runtime v0.34.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.19 h1:ybEda2mkkX
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.33.19/go.mod h1:RiMytGvN4azx4yLM0Kn3bX/XO9dLxj+eG72Smy+vNzI=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.11 h1:0iNKMyO0SXuRfl5FF6TQASAHTXnTYZlQS3/oJSfpEbQ=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.11/go.mod h1:WdVArS8riWgCC1JoIVmKdqfBfj2+cSWAjBU5dEapMhA=
+github.com/aws/aws-sdk-go-v2/service/iam v1.53.8 h1:p0oB4eZfBfBAOasnKvHJOlNcuHVE/ieuWs7uIZgQlyQ=
+github.com/aws/aws-sdk-go-v2/service/iam v1.53.8/go.mod h1:epCaPnGVdiX5ra1lHPfRkVuiQGxrdY8bRI2FBJU+6ok=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4 h1:0ryTNEdJbzUCEWkVXEXoqlXV72J5keC1GvILMOuD00E=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4/go.mod h1:HQ4qwNZh32C3CBeO6iJLQlgtMzqeG17ziAA/3KDJFow=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.8 h1:Z5EiPIzXKewUQK0QTMkutjiaPVeVYXX7KIqhXu/0fXs=

--- a/pkg/provider/aws/credentials.go
+++ b/pkg/provider/aws/credentials.go
@@ -1,0 +1,152 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/nebari-dev/nebari-infrastructure-core/pkg/config"
+	"github.com/nebari-dev/nebari-infrastructure-core/pkg/provider"
+	"github.com/nebari-dev/nebari-infrastructure-core/pkg/status"
+)
+
+// iamSimulateBatchSize is the maximum number of action names per
+// SimulatePrincipalPolicy call. The AWS API caps this at 100.
+const iamSimulateBatchSize = 100
+
+// IAMClient defines the IAM operations needed for credential validation.
+type IAMClient interface {
+	SimulatePrincipalPolicy(ctx context.Context, params *iam.SimulatePrincipalPolicyInput, optFns ...func(*iam.Options)) (*iam.SimulatePrincipalPolicyOutput, error)
+}
+
+// newIAMClient creates a new IAM client for the specified region.
+func newIAMClient(ctx context.Context, region string) (IAMClient, error) {
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(region))
+	if err != nil {
+		return nil, fmt.Errorf("failed to load AWS config: %w", err)
+	}
+	return iam.NewFromConfig(cfg), nil
+}
+
+// CredentialValidationResult contains the results of credential validation.
+type CredentialValidationResult struct {
+	AccountID          string
+	Arn                string
+	MissingPermissions []string
+}
+
+// validateCredentialsWithClients performs thorough credential validation using
+// provided clients (for testability).
+func validateCredentialsWithClients(ctx context.Context, stsClient STSClient, iamClient IAMClient, cfg *Config) (*CredentialValidationResult, error) {
+	tracer := otel.Tracer("nebari-infrastructure-core")
+	ctx, span := tracer.Start(ctx, "aws.validateCredentialsWithClients")
+	defer span.End()
+
+	identity, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		span.RecordError(err)
+		return nil, fmt.Errorf("failed to get caller identity: %w", err)
+	}
+
+	result := &CredentialValidationResult{
+		AccountID: aws.ToString(identity.Account),
+		Arn:       aws.ToString(identity.Arn),
+	}
+
+	span.SetAttributes(
+		attribute.String("aws.account_id", result.AccountID),
+		attribute.String("aws.arn", result.Arn),
+	)
+
+	requiredPerms := getRequiredPermissions(cfg)
+
+	var missingPerms []string
+	for batch := range slices.Chunk(requiredPerms, iamSimulateBatchSize) {
+		simResult, err := iamClient.SimulatePrincipalPolicy(ctx, &iam.SimulatePrincipalPolicyInput{
+			PolicySourceArn: identity.Arn,
+			ActionNames:     batch,
+			ResourceArns:    []string{"*"},
+		})
+		if err != nil {
+			span.RecordError(err)
+			return nil, fmt.Errorf("failed to simulate IAM policy: %w", err)
+		}
+
+		for _, evalResult := range simResult.EvaluationResults {
+			if evalResult.EvalDecision != iamtypes.PolicyEvaluationDecisionTypeAllowed {
+				missingPerms = append(missingPerms, aws.ToString(evalResult.EvalActionName))
+			}
+		}
+	}
+
+	result.MissingPermissions = missingPerms
+
+	span.SetAttributes(
+		attribute.Int("permissions.checked", len(requiredPerms)),
+		attribute.Int("permissions.missing", len(missingPerms)),
+	)
+
+	return result, nil
+}
+
+// ValidateCredentials implements provider.CredentialValidator for thorough
+// credential validation including IAM permission checks.
+func (p *Provider) ValidateCredentials(ctx context.Context, projectName string, clusterConfig *config.ClusterConfig) error {
+	tracer := otel.Tracer("nebari-infrastructure-core")
+	ctx, span := tracer.Start(ctx, "aws.ValidateCredentials")
+	defer span.End()
+
+	span.SetAttributes(attribute.String("project_name", projectName))
+
+	awsCfg, err := extractAWSConfig(ctx, clusterConfig)
+	if err != nil {
+		span.RecordError(err)
+		return err
+	}
+
+	stsClient, err := newSTSClient(ctx, awsCfg.Region)
+	if err != nil {
+		span.RecordError(err)
+		return fmt.Errorf("failed to create STS client: %w", err)
+	}
+
+	iamClient, err := newIAMClient(ctx, awsCfg.Region)
+	if err != nil {
+		span.RecordError(err)
+		return fmt.Errorf("failed to create IAM client: %w", err)
+	}
+
+	result, err := validateCredentialsWithClients(ctx, stsClient, iamClient, awsCfg)
+	if err != nil {
+		span.RecordError(err)
+		return err
+	}
+
+	status.Send(ctx, status.NewUpdate(status.LevelSuccess, "AWS credentials validated").
+		WithResource("credentials").
+		WithAction("validated").
+		WithMetadata("identity", result.Arn).
+		WithMetadata("account", result.AccountID))
+
+	if len(result.MissingPermissions) > 0 {
+		status.Send(ctx, status.NewUpdate(status.LevelError, fmt.Sprintf("Missing %d required permissions: %s", len(result.MissingPermissions), strings.Join(result.MissingPermissions, ", "))).
+			WithResource("credentials").
+			WithAction("validated").
+			WithMetadata("missing_permissions", result.MissingPermissions))
+		return fmt.Errorf("credential validation failed: missing %d permissions: %s", len(result.MissingPermissions), strings.Join(result.MissingPermissions, ", "))
+	}
+
+	return nil
+}
+
+// Compile-time check that Provider implements CredentialValidator.
+var _ provider.CredentialValidator = (*Provider)(nil)

--- a/pkg/provider/aws/credentials_test.go
+++ b/pkg/provider/aws/credentials_test.go
@@ -1,0 +1,250 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+// mockIAMClient implements IAMClient for testing.
+type mockIAMClient struct {
+	SimulatePrincipalPolicyFunc func(ctx context.Context, params *iam.SimulatePrincipalPolicyInput, optFns ...func(*iam.Options)) (*iam.SimulatePrincipalPolicyOutput, error)
+}
+
+func (m *mockIAMClient) SimulatePrincipalPolicy(ctx context.Context, params *iam.SimulatePrincipalPolicyInput, optFns ...func(*iam.Options)) (*iam.SimulatePrincipalPolicyOutput, error) {
+	if m.SimulatePrincipalPolicyFunc != nil {
+		return m.SimulatePrincipalPolicyFunc(ctx, params, optFns...)
+	}
+	return &iam.SimulatePrincipalPolicyOutput{}, nil
+}
+
+func TestMockIAMClient(t *testing.T) {
+	var _ IAMClient = &mockIAMClient{}
+}
+
+func TestGetRequiredPermissions(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         *Config
+		mustHave    []string
+		mustNotHave []string
+	}{
+		{
+			name: "minimal config includes base, VPC, IAM and excludes EFS",
+			cfg: &Config{
+				Region:     "us-east-1",
+				NodeGroups: map[string]NodeGroup{"general": {Instance: "t3.medium"}},
+			},
+			mustHave: []string{
+				"sts:GetCallerIdentity",
+				"s3:CreateBucket",
+				"eks:CreateCluster",
+				"ec2:CreateVpc",
+				"iam:CreateRole",
+			},
+			mustNotHave: []string{"elasticfilesystem:CreateFileSystem"},
+		},
+		{
+			name: "skips VPC permissions when existing VPC provided",
+			cfg: &Config{
+				Region:        "us-east-1",
+				ExistingVPCID: "vpc-12345678",
+				NodeGroups:    map[string]NodeGroup{"general": {Instance: "t3.medium"}},
+			},
+			mustHave:    []string{"eks:CreateCluster", "iam:CreateRole"},
+			mustNotHave: []string{"ec2:CreateVpc", "ec2:DeleteVpc"},
+		},
+		{
+			name: "skips IAM permissions when existing cluster role provided",
+			cfg: &Config{
+				Region:                 "us-east-1",
+				ExistingClusterRoleArn: "arn:aws:iam::123456789012:role/existing-role",
+				NodeGroups:             map[string]NodeGroup{"general": {Instance: "t3.medium"}},
+			},
+			mustHave:    []string{"eks:CreateCluster", "ec2:CreateVpc"},
+			mustNotHave: []string{"iam:CreateRole", "iam:DeleteRole"},
+		},
+		{
+			name: "includes EFS permissions when EFS enabled",
+			cfg: &Config{
+				Region:     "us-east-1",
+				NodeGroups: map[string]NodeGroup{"general": {Instance: "t3.medium"}},
+				EFS:        &EFSConfig{Enabled: true},
+			},
+			mustHave: []string{
+				"elasticfilesystem:CreateFileSystem",
+				"elasticfilesystem:DeleteFileSystem",
+				"elasticfilesystem:CreateMountTarget",
+			},
+		},
+		{
+			name: "excludes EFS permissions when EFS disabled",
+			cfg: &Config{
+				Region:     "us-east-1",
+				NodeGroups: map[string]NodeGroup{"general": {Instance: "t3.medium"}},
+				EFS:        &EFSConfig{Enabled: false},
+			},
+			mustNotHave: []string{"elasticfilesystem:CreateFileSystem"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			perms := getRequiredPermissions(tt.cfg)
+			for _, p := range tt.mustHave {
+				if !slices.Contains(perms, p) {
+					t.Errorf("missing permission %q", p)
+				}
+			}
+			for _, p := range tt.mustNotHave {
+				if slices.Contains(perms, p) {
+					t.Errorf("should not have permission %q", p)
+				}
+			}
+		})
+	}
+}
+
+func newTestSTSMock() *mockSTSClient {
+	return &mockSTSClient{
+		GetCallerIdentityFunc: func(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+			return &sts.GetCallerIdentityOutput{
+				Account: aws.String("123456789012"),
+				Arn:     aws.String("arn:aws:iam::123456789012:user/test-user"),
+				UserId:  aws.String("AIDAEXAMPLE"),
+			}, nil
+		},
+	}
+}
+
+func allowAllIAMMock() *mockIAMClient {
+	return &mockIAMClient{
+		SimulatePrincipalPolicyFunc: func(ctx context.Context, params *iam.SimulatePrincipalPolicyInput, optFns ...func(*iam.Options)) (*iam.SimulatePrincipalPolicyOutput, error) {
+			results := make([]iamtypes.EvaluationResult, len(params.ActionNames))
+			for i, action := range params.ActionNames {
+				results[i] = iamtypes.EvaluationResult{
+					EvalActionName: aws.String(action),
+					EvalDecision:   iamtypes.PolicyEvaluationDecisionTypeAllowed,
+				}
+			}
+			return &iam.SimulatePrincipalPolicyOutput{EvaluationResults: results}, nil
+		},
+	}
+}
+
+func TestValidateCredentialsWithClients(t *testing.T) {
+	baseCfg := &Config{
+		Region:     "us-east-1",
+		NodeGroups: map[string]NodeGroup{"general": {Instance: "t3.medium"}},
+	}
+
+	t.Run("success with all permissions allowed", func(t *testing.T) {
+		result, err := validateCredentialsWithClients(context.Background(), newTestSTSMock(), allowAllIAMMock(), baseCfg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.AccountID != "123456789012" {
+			t.Errorf("AccountID = %q, want %q", result.AccountID, "123456789012")
+		}
+		if result.Arn != "arn:aws:iam::123456789012:user/test-user" {
+			t.Errorf("Arn = %q, want %q", result.Arn, "arn:aws:iam::123456789012:user/test-user")
+		}
+		if len(result.MissingPermissions) != 0 {
+			t.Errorf("MissingPermissions = %v, want empty", result.MissingPermissions)
+		}
+	})
+
+	t.Run("reports missing permissions", func(t *testing.T) {
+		denied := map[string]bool{"eks:CreateCluster": true, "iam:CreateRole": true}
+		iamMock := &mockIAMClient{
+			SimulatePrincipalPolicyFunc: func(ctx context.Context, params *iam.SimulatePrincipalPolicyInput, optFns ...func(*iam.Options)) (*iam.SimulatePrincipalPolicyOutput, error) {
+				results := make([]iamtypes.EvaluationResult, len(params.ActionNames))
+				for i, action := range params.ActionNames {
+					decision := iamtypes.PolicyEvaluationDecisionTypeAllowed
+					if denied[action] {
+						decision = iamtypes.PolicyEvaluationDecisionTypeImplicitDeny
+					}
+					results[i] = iamtypes.EvaluationResult{
+						EvalActionName: aws.String(action),
+						EvalDecision:   decision,
+					}
+				}
+				return &iam.SimulatePrincipalPolicyOutput{EvaluationResults: results}, nil
+			},
+		}
+
+		result, err := validateCredentialsWithClients(context.Background(), newTestSTSMock(), iamMock, baseCfg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result.MissingPermissions) != 2 {
+			t.Errorf("MissingPermissions count = %d, want 2", len(result.MissingPermissions))
+		}
+		for _, want := range []string{"eks:CreateCluster", "iam:CreateRole"} {
+			if !slices.Contains(result.MissingPermissions, want) {
+				t.Errorf("MissingPermissions should contain %q", want)
+			}
+		}
+	})
+
+	t.Run("error on STS GetCallerIdentity failure", func(t *testing.T) {
+		stsMock := &mockSTSClient{
+			GetCallerIdentityFunc: func(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+				return nil, fmt.Errorf("invalid credentials")
+			},
+		}
+		if _, err := validateCredentialsWithClients(context.Background(), stsMock, &mockIAMClient{}, baseCfg); err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+
+	t.Run("error on IAM SimulatePrincipalPolicy failure", func(t *testing.T) {
+		iamMock := &mockIAMClient{
+			SimulatePrincipalPolicyFunc: func(ctx context.Context, params *iam.SimulatePrincipalPolicyInput, optFns ...func(*iam.Options)) (*iam.SimulatePrincipalPolicyOutput, error) {
+				return nil, fmt.Errorf("access denied to simulate policy")
+			},
+		}
+		if _, err := validateCredentialsWithClients(context.Background(), newTestSTSMock(), iamMock, baseCfg); err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+
+	t.Run("batches permissions in groups of 100", func(t *testing.T) {
+		callCount := 0
+		iamMock := &mockIAMClient{
+			SimulatePrincipalPolicyFunc: func(ctx context.Context, params *iam.SimulatePrincipalPolicyInput, optFns ...func(*iam.Options)) (*iam.SimulatePrincipalPolicyOutput, error) {
+				callCount++
+				if len(params.ActionNames) > iamSimulateBatchSize {
+					t.Errorf("batch size = %d, want <= %d", len(params.ActionNames), iamSimulateBatchSize)
+				}
+				results := make([]iamtypes.EvaluationResult, len(params.ActionNames))
+				for i, action := range params.ActionNames {
+					results[i] = iamtypes.EvaluationResult{
+						EvalActionName: aws.String(action),
+						EvalDecision:   iamtypes.PolicyEvaluationDecisionTypeAllowed,
+					}
+				}
+				return &iam.SimulatePrincipalPolicyOutput{EvaluationResults: results}, nil
+			},
+		}
+
+		cfg := &Config{
+			Region:     "us-east-1",
+			NodeGroups: map[string]NodeGroup{"general": {Instance: "t3.medium"}},
+			EFS:        &EFSConfig{Enabled: true},
+		}
+
+		if _, err := validateCredentialsWithClients(context.Background(), newTestSTSMock(), iamMock, cfg); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if callCount == 0 {
+			t.Error("expected SimulatePrincipalPolicy to be called at least once")
+		}
+	})
+}

--- a/pkg/provider/aws/permissions.go
+++ b/pkg/provider/aws/permissions.go
@@ -1,0 +1,124 @@
+package aws
+
+// awsBasePermissions is the set of AWS IAM permissions required for every
+// Nebari deployment, regardless of configuration. Permissions for optional
+// resources (VPC, IAM, EFS) are added by getRequiredPermissions based on
+// the provided Config.
+var awsBasePermissions = []string{
+	// STS
+	"sts:GetCallerIdentity",
+
+	// S3 - state bucket management
+	"s3:HeadBucket",
+	"s3:CreateBucket",
+	"s3:PutBucketVersioning",
+	"s3:PutPublicAccessBlock",
+	"s3:ListObjectVersions",
+	"s3:DeleteObject",
+	"s3:DeleteBucket",
+
+	// EC2 - core
+	"ec2:DescribeAvailabilityZones",
+	"ec2:CreateTags",
+	"ec2:DeleteTags",
+
+	// EKS
+	"eks:CreateCluster",
+	"eks:DeleteCluster",
+	"eks:DescribeCluster",
+	"eks:UpdateClusterVersion",
+	"eks:UpdateClusterConfig",
+	"eks:CreateNodegroup",
+	"eks:DeleteNodegroup",
+	"eks:DescribeNodegroup",
+	"eks:ListNodegroups",
+	"eks:UpdateNodegroupConfig",
+	"eks:TagResource",
+	"eks:UntagResource",
+}
+
+// awsVPCPermissions are required when Nebari provisions its own VPC. Skip
+// when ExistingVPCID is provided.
+var awsVPCPermissions = []string{
+	"ec2:CreateVpc",
+	"ec2:DeleteVpc",
+	"ec2:DescribeVpcs",
+	"ec2:ModifyVpcAttribute",
+	"ec2:CreateSubnet",
+	"ec2:DeleteSubnet",
+	"ec2:DescribeSubnets",
+	"ec2:CreateInternetGateway",
+	"ec2:DeleteInternetGateway",
+	"ec2:AttachInternetGateway",
+	"ec2:DetachInternetGateway",
+	"ec2:DescribeInternetGateways",
+	"ec2:AllocateAddress",
+	"ec2:ReleaseAddress",
+	"ec2:DescribeAddresses",
+	"ec2:CreateNatGateway",
+	"ec2:DeleteNatGateway",
+	"ec2:DescribeNatGateways",
+	"ec2:CreateRouteTable",
+	"ec2:DeleteRouteTable",
+	"ec2:DescribeRouteTables",
+	"ec2:CreateRoute",
+	"ec2:AssociateRouteTable",
+	"ec2:DisassociateRouteTable",
+	"ec2:CreateSecurityGroup",
+	"ec2:DeleteSecurityGroup",
+	"ec2:DescribeSecurityGroups",
+	"ec2:AuthorizeSecurityGroupIngress",
+	"ec2:AuthorizeSecurityGroupEgress",
+	"ec2:CreateVpcEndpoint",
+	"ec2:DeleteVpcEndpoints",
+	"ec2:DescribeVpcEndpoints",
+	"ec2:DescribeNetworkInterfaces",
+}
+
+// awsIAMPermissions are required when Nebari creates the EKS cluster role.
+// Skip when ExistingClusterRoleArn is provided.
+var awsIAMPermissions = []string{
+	"iam:CreateRole",
+	"iam:DeleteRole",
+	"iam:GetRole",
+	"iam:AttachRolePolicy",
+	"iam:DetachRolePolicy",
+	"iam:ListAttachedRolePolicies",
+	"iam:PassRole",
+	"iam:TagRole",
+}
+
+// awsEFSPermissions are required when EFS is enabled.
+var awsEFSPermissions = []string{
+	"elasticfilesystem:CreateFileSystem",
+	"elasticfilesystem:DeleteFileSystem",
+	"elasticfilesystem:DescribeFileSystems",
+	"elasticfilesystem:CreateMountTarget",
+	"elasticfilesystem:DeleteMountTarget",
+	"elasticfilesystem:DescribeMountTargets",
+	"elasticfilesystem:TagResource",
+}
+
+// getRequiredPermissions returns the list of AWS IAM permissions required
+// based on the configuration. Permission sets are defined in this file and
+// composed conditionally:
+//   - VPC permissions skipped when ExistingVPCID is set
+//   - IAM permissions skipped when ExistingClusterRoleArn is set
+//   - EFS permissions only included when EFS.Enabled is true
+func getRequiredPermissions(cfg *Config) []string {
+	perms := append([]string(nil), awsBasePermissions...)
+
+	if cfg.ExistingVPCID == "" {
+		perms = append(perms, awsVPCPermissions...)
+	}
+
+	if cfg.ExistingClusterRoleArn == "" {
+		perms = append(perms, awsIAMPermissions...)
+	}
+
+	if cfg.EFS != nil && cfg.EFS.Enabled {
+		perms = append(perms, awsEFSPermissions...)
+	}
+
+	return perms
+}

--- a/pkg/provider/aws/provider.go
+++ b/pkg/provider/aws/provider.go
@@ -6,7 +6,8 @@ import (
 	"fmt"
 	"time"
 
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/hashicorp/terraform-exec/tfexec"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -191,18 +192,25 @@ func (p *Provider) Validate(ctx context.Context, projectName string, clusterConf
 		}
 	}
 
-	// Validate AWS credentials
-	sdkCfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(awsCfg.Region))
+	// Validate AWS credentials using STS GetCallerIdentity. This is a single
+	// API call that returns the caller's identity if credentials are valid,
+	// and is more reliable than Credentials.Retrieve which only checks the
+	// local credential chain without confirming AWS will accept them.
+	stsClient, err := newSTSClient(ctx, awsCfg.Region)
 	if err != nil {
 		span.RecordError(err)
-		return fmt.Errorf("failed to load AWS config: %w", err)
+		return fmt.Errorf("failed to create STS client: %w", err)
 	}
-	if _, err := sdkCfg.Credentials.Retrieve(ctx); err != nil {
+
+	identity, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
 		span.RecordError(err)
-		return fmt.Errorf("failed to retrieve AWS credentials: %w", err)
+		return fmt.Errorf("AWS credential validation failed: %w", err)
 	}
 
 	span.SetAttributes(
+		attribute.String("aws.account_id", aws.ToString(identity.Account)),
+		attribute.String("aws.arn", aws.ToString(identity.Arn)),
 		attribute.Bool("validation_passed", true),
 		attribute.String("aws.region", awsCfg.Region),
 	)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -113,3 +113,15 @@ type Provider interface {
 	// without importing provider packages or switching on provider names.
 	InfraSettings(clusterConfig *config.ClusterConfig) InfraSettings
 }
+
+// CredentialValidator is an optional interface for providers that support
+// thorough credential validation beyond basic authentication.
+// Providers implement this to enable the --validate-creds flag.
+// Providers that don't implement this (e.g., local) will show a message
+// indicating the flag is not supported.
+type CredentialValidator interface {
+	// ValidateCredentials performs thorough credential validation including
+	// permission checks using provider-specific APIs (e.g., IAM Policy Simulator).
+	// Returns nil if all required permissions are present.
+	ValidateCredentials(ctx context.Context, projectName string, clusterConfig *config.ClusterConfig) error
+}


### PR DESCRIPTION
## Summary

Implements AWS credential validation as described in #6. This adds:

- **Default validation**: Silent `sts:GetCallerIdentity` check on every `nic validate` command
- **Thorough validation**: `--validate-creds` flag runs IAM Policy Simulator to verify all required permissions
- **Config-aware permissions**: Skips VPC/IAM/EFS permission checks based on configuration

## Changes

### New Interface
- Added optional `CredentialValidator` interface to `pkg/provider/provider.go`
- Providers can opt-in to thorough credential validation

### CLI Flag
- Added `--validate-creds` flag to `nic validate` command
- Shows helpful message for providers that don't support it

### AWS Implementation
- `pkg/provider/aws/credentials.go`: Core validation logic
  - `getRequiredPermissions()`: Config-aware permission list builder
  - `validateCredentialsWithClients()`: IAM Policy Simulator integration
  - `ValidateCredentials()`: Provider method implementation
- Updated `Validate()` to use `GetCallerIdentity` for basic credential check

### Permissions Checked
- **Always required**: STS, S3 (state bucket), EC2 (core), EKS
- **Conditional**: VPC creation (skip if `existing_vpc_id`), IAM roles (skip if `existing_cluster_role_arn`), EFS (only if enabled)

## Test Plan

- [x] Unit tests for `getRequiredPermissions()` with various config combinations
- [x] Unit tests for `validateCredentialsWithClients()` with mocked AWS clients
- [x] Tests for error cases (invalid credentials, missing permissions)
- [x] All existing tests pass
- [x] `golangci-lint` passes with 0 issues
- [x] CLI help shows new `--validate-creds` flag

## Usage

```bash
# Basic validation (silent credential check)
nic validate -f config.yaml

# Thorough credential validation
nic validate -f config.yaml --validate-creds
```

## Related Issues

- Closes #6
- Related to #54 (future `--gen-perms` flag)