### PR TITLE
Add dynamic handling for light/dark theme themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <a href="https://nebari.dev">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/nebari-dev/nebari-design/blob/main/logo-mark/colored-background/Nebari-Logo-Black-Bg.png?raw=true" width="400" >
-      <img src="docs/assets/nebari-logo.svg" alt="Nebari" style="border-radius: 12px; border: 2px solid white;">
+      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/nebari-dev/nebari-design/blob/main/logo-mark/colored-background/Nebari-Logo-Black-Bg.png?raw=true">
+      <img src="docs/assets/nebari-logo.svg" alt="Nebari" width="400" style="border-radius: 12px;">
     </picture>
   </a>
 </p>


### PR DESCRIPTION
Suggest a small change to the README main Nebari logo to better work on the Darker GitHub theme environments. 

Right now, on dark themes, it looks like this:
<img width="1846" height="1130" alt="image" src="https://github.com/user-attachments/assets/42f1b5a1-7e3b-46d3-aac3-c21441835896" />

With this change
