### PR TITLE
Fix KC_HOSTNAME for Keycloak 26 hostname v2

### DIFF
--- a/pkg/argocd/templates/apps/keycloak.yaml
+++ b/pkg/argocd/templates/apps/keycloak.yaml
@@ -46,9 +46,7 @@ spec:
                   name: keycloak-postgresql-credentials
                   key: password
             - name: KC_HOSTNAME
-              value: "keycloak.{{ .Domain }}"
-            - name: KC_HOSTNAME_STRICT
-              value: "true"
+              value: "https://keycloak.{{ .Domain }}/auth"
           proxy:
             mode: xforwarded
           livenessProbe: |


### PR DESCRIPTION
## Closes

Closes #108

## Description

Keycloak 26 replaced hostname v1 with v2. KC_HOSTNAME now accepts a full URL, and KC_HOSTNAME_STRICT is a deprecated v1 option that is silently ignored. Pass the full URL with scheme and context path so OIDC discovery returns correct https URLs.


## How to Test

1. Deploy with the updated keycloak.yaml template and wait for ArgoCD to sync
2. Verify Keycloak logs no longer show WARNING: Hostname v1 options warnings:
kubectl logs keycloak-keycloakx-0 -n keycloak | grep -i "hostname v1"
3. Verify OIDC discovery returns https URLs (no port 8080):
kubectl run curl-test --rm -it --restart=Never --image=curlimages/curl -n keycloak -- \
  curl -s http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/auth/realms/nebari/.well-known/openid-configuration
3. Expected: "issuer": "https://keycloak.<domain>/auth/realms/nebari"
4. Confirm the application behind Envoy Gateway redirects to https://keycloak.<domain>/auth/... (not http://:8080)
