### PR TITLE
Update OpenTofu version to 1.11.3 to include fix for locked state

### DIFF
--- a/pkg/tofu/version.go
+++ b/pkg/tofu/version.go
@@ -1,4 +1,4 @@
 package tofu
 
 // DefaultVersion is the default OpenTofu version downloaded and used by NIC
-const DefaultVersion = "1.11.2"
+const DefaultVersion = "1.11.3"


### PR DESCRIPTION
## Closes

Closes #63

## Description

This PR supersedes #115 and bumps the version of OpenTofu to 1.11.3 to include a fix for https://github.com/opentofu/opentofu/issues/3624. This issue was making tofu to be unable to release the lock when one of its operation was cancelled.
 
## How to Test

From the main branch, run either nic destroy or nic deploy and cancel the command once tofu is running by pressing Crtl+C. You'll see that there was an error releasing the state lock. For example:

```
^C{"time":"2026-02-19T10:50:14.294058+01:00","level":"WARN","msg":"Received interrupt signal, initiating graceful shutdown","signal":"interrupt"}
Stopping operation...

Interrupt received.
Please wait for OpenTofu to exit or data loss may occur.
Gracefully shutting down...


Error: Error releasing the state lock

Error message: failed to retrieve s3 lock info: operation error S3:
GetObject, context canceled

OpenTofu acquires a lock when accessing your state to prevent others
running OpenTofu to potentially modify the state at the same time. An
error occurred while releasing this lock. This could mean that the lock
did or did not release properly. If the lock didn't release properly,
OpenTofu may not be able to run future commands since it'll appear as if
the lock is held.

In this scenario, please call the "force-unlock" command to unlock the
state manually. This is a very dangerous operation since if it is done
erroneously it could result in two people modifying state at the same time.
Only call this command if you're certain that the unlock above failed and
that no one else is holding a lock.

Error: operation canceled

{"time":"2026-02-19T10:50:14.565368+01:00","level":"ERROR","msg":"Destruction failed","error":"exit status 1","provider":"aws"}
{"time":"2026-02-19T10:50:14.565407+01:00","level":"WARN","msg":"Destruction interrupted by user"}
```

Unlock the state manually, and then from this branch (don't forget to rebuild), run the same command and cancel it again once tofu is running by pressing Crtl+C. There should be no error trying to release the lock.