### PR TITLE
Rename DefaultVersion to TofuVersion for clarity

### DIFF
--- a/cmd/nic/version.go
+++ b/cmd/nic/version.go
@@ -34,7 +34,7 @@ func runVersion(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Nebari Infrastructure Core (NIC)\n")
 	fmt.Printf("Version: %s\n", version)
 	fmt.Printf("Commit: %s\n", commit)
-	fmt.Printf("OpenTofu version: %s\n", tofu.TofuVersion)
+	fmt.Printf("OpenTofu version: %s\n", tofu.Version)
 
 	// Show registered providers
 	providers := registry.List(ctx)

--- a/pkg/tofu/tofu.go
+++ b/pkg/tofu/tofu.go
@@ -209,7 +209,7 @@ func Setup(ctx context.Context, templates fs.FS, tfvars any) (te *TerraformExecu
 		return nil, fmt.Errorf("failed to get plugin cache directory: %w", err)
 	}
 
-	downloader := &tofuDownloader{cacheDir: cacheDir, version: TofuVersion}
+	downloader := &tofuDownloader{cacheDir: cacheDir, version: Version}
 	execPath, err := downloadExecutable(ctx, appFs, cacheDir, downloader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get executable: %w", err)

--- a/pkg/tofu/version.go
+++ b/pkg/tofu/version.go
@@ -1,4 +1,4 @@
 package tofu
 
-// TofuVersion is the OpenTofu version downloaded and used by NIC
-const TofuVersion = "1.11.3"
+// Version is the OpenTofu version downloaded and used by NIC
+const Version = "1.11.3"

--- a/pkg/tofu/version_test.go
+++ b/pkg/tofu/version_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 )
 
-func TestTofuVersion(t *testing.T) {
-	if TofuVersion == "" {
-		t.Error("TofuVersion should not be empty")
+func TestVersion(t *testing.T) {
+	if Version == "" {
+		t.Error("Version should not be empty")
 	}
 
-	parts := strings.Split(TofuVersion, ".")
+	parts := strings.Split(Version, ".")
 	if len(parts) < 2 {
-		t.Errorf("TofuVersion = %v, expected semver format (x.y.z)", TofuVersion)
+		t.Errorf("Version = %v, expected semver format (x.y.z)", Version)
 	}
 }


### PR DESCRIPTION
## Closes

## Description

This is a very small PR renaming the `DefaultVersion` variable in the `tofu` package to `TofuVersion`. This makes it clearer as we're not supporting overriding this variable in any way and our intent is to keep it pinned to a specific version to ensure reproducibility. Thus, the name `DefaultVersion` is misleading.

## How to Test