### PR TITLE
feat(integration): add LocalStack-based Terraform S3 integration test

### DIFF
--- a/pkg/provider/aws/integration_test.go
+++ b/pkg/provider/aws/integration_test.go
@@ -3,17 +3,73 @@
 package aws
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
+	"time"
 )
 
-// TODO: Rewrite integration tests to use Terraform/OpenTofu
-// The previous tests used direct AWS SDK calls which have been replaced
-// with Terraform for infrastructure management.
-//
-// For testing with LocalStack, we'll se tflocal (LocalStack's Terraform wrapper) or
-// configure the AWS provider with custom endpoints pointing to LocalStack
-// See: https://docs.localstack.cloud/user-guide/integrations/terraform/
+func TestIntegration_LocalStack_S3(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 
-func TestIntegration_Placeholder(t *testing.T) {
-	t.Skip("Integration tests need to be rewritten for Terraform-based infrastructure")
+	tempDir := t.TempDir()
+
+	// Generate unique bucket name
+	bucketName := fmt.Sprintf("integration-test-bucket-%d", time.Now().Unix())
+
+	tfConfig := fmt.Sprintf(`
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
+provider "aws" {
+  region                      = "us-east-2"
+  access_key                  = "test"
+  secret_key                  = "test"
+
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  skip_metadata_api_check     = true
+  skip_region_validation      = true
+
+  s3_use_path_style           = true
+
+  endpoints {
+    s3 = "http://localhost:4566"
+  }
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket = "%s"
+}
+`, bucketName)
+
+	mainFile := filepath.Join(tempDir, "main.tf")
+
+	if err := os.WriteFile(mainFile, []byte(tfConfig), 0644); err != nil {
+		t.Fatalf("failed to write terraform config: %v", err)
+	}
+
+	run := func(args ...string) {
+		cmd := exec.Command("terraform", args...)
+		cmd.Dir = tempDir
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("terraform %v failed: %v", args, err)
+		}
+	}
+
+	run("init", "-input=false")
+	run("apply", "-auto-approve", "-input=false")
+	run("destroy", "-auto-approve", "-input=false")
 }


### PR DESCRIPTION
## Summary

This PR rewrites the AWS provider integration test to use Terraform with LocalStack, replacing the previous AWS SDK–based approach that was removed in #34.

## What’s Included

- Introduces a LocalStack-backed integration test using Terraform
- Validates full resource lifecycle (init → apply → destroy)
- Uses an isolated temp directory to avoid polluting the repository
- Dynamically generates unique resource names
- Skips in short test mode

## Notes

This PR introduces a minimal S3-based integration test as a foundation. Future PRs can extend coverage to module templates once LocalStack compatibility is clarified.