### PR TITLE
Update nebari-operator to version 0.1.0-alpha.5

### DIFF
--- a/pkg/argocd/templates/manifests/nebari-operator/kustomization.yaml
+++ b/pkg/argocd/templates/manifests/nebari-operator/kustomization.yaml
@@ -4,11 +4,11 @@ kind: Kustomization
 namespace: nebari-operator-system
 
 resources:
-  - https://github.com/nebari-dev/nebari-operator.git/config/default?ref=v0.1.0-alpha.4
+  - https://github.com/nebari-dev/nebari-operator.git/config/default?ref=v0.1.0-alpha.5
 
 images:
   - name: quay.io/nebari/nebari-operator
-    newTag: 0.1.0-alpha.4
+    newTag: 0.1.0-alpha.5
 
 patches:
   - path: deployment-patch.yaml


### PR DESCRIPTION
Updates the version of the nebari-operator to latest (recent release) v.0.1.0-alpha.5