### PR TITLE
fix(hetzner): prevent SSH agent keys from triggering fail2ban IP bans

### DIFF
--- a/pkg/provider/hetzner/binary.go
+++ b/pkg/provider/hetzner/binary.go
@@ -34,7 +34,7 @@ func verifyChecksum(data []byte, osName, arch string) error {
 
 const (
 	// DefaultHetznerK3sVersion is the pinned hetzner-k3s release version.
-	DefaultHetznerK3sVersion = "v2.4.5"
+	DefaultHetznerK3sVersion = "v2.4.6"
 
 	defaultBaseURL  = "https://github.com/vitobotta/hetzner-k3s/releases/download"
 	downloadTimeout = 5 * time.Minute
@@ -48,10 +48,10 @@ const (
 // knownChecksums maps "os-arch" to the expected SHA256 hex digest for the pinned version.
 // Update these when bumping DefaultHetznerK3sVersion.
 var knownChecksums = map[string]string{
-	"linux-amd64": "18bbfe3d066539a967419d052ac0f8b4ad4691f2f76f9f22d7433c10ef28fea5",
-	"linux-arm64": "0b60c018842fd7f6c53116e439f5e25ec8b0c5d7d04710c81f7d50549e6fb194",
-	"macos-amd64": "803b2503a9bad0f9dbeadcc8f7ab23844e1d027da6ab27dd627ccd53a6000818",
-	"macos-arm64": "31d69c5666c3e4a96309ca770c80e03d846d1c83754f49679765b1588806c1bd",
+	"linux-amd64": "46b898da949271ad45c96805b45019e8cc3cb10efe9708809a3c9e393e195b86",
+	"linux-arm64": "1fe10ac060cf134848b91a86904cfd4bc5a893a5eb0e56f78e307b4afb4fb633",
+	"macos-amd64": "d07075daa6893169b2ca42f42eebc1e827193ed94d32cb7f15d300a24bdea564",
+	"macos-arm64": "5be8e4b5b4368c49276ec04fe0a5d0bb5fdc584f6e6ebe580c55fc822178a87f",
 }
 
 // binaryDownloader abstracts binary fetching for testability.

--- a/pkg/provider/hetzner/cluster.go
+++ b/pkg/provider/hetzner/cluster.go
@@ -166,11 +166,18 @@ func runHetznerK3s(ctx context.Context, binaryPath, subcommand, clusterYAMLPath 
 
 // minimalEnv constructs a minimal set of environment variables for the hetzner-k3s subprocess.
 // Only variables required for the binary to function are included, preventing credential leakage.
+//
+// SSH_AUTH_SOCK is intentionally excluded: the cluster.yaml is always generated with
+// use_agent: false, meaning hetzner-k3s passes -i <private_key_path> to the ssh binary.
+// Forwarding SSH_AUTH_SOCK would cause the ssh binary to offer every key loaded in the
+// agent before the specified identity key, quickly exceeding sshd's MaxAuthTries (default 6)
+// on the freshly-created node. Repeated MaxAuthTries violations are then banned by fail2ban,
+// making the node permanently unreachable for the rest of the deployment.
 func minimalEnv() []string {
 	env := []string{
 		"HCLOUD_TOKEN=" + os.Getenv("HETZNER_TOKEN"),
 	}
-	for _, key := range []string{"HOME", "PATH", "USER", "TERM", "LANG", "TMPDIR", "SSH_AUTH_SOCK"} {
+	for _, key := range []string{"HOME", "PATH", "USER", "TERM", "LANG", "TMPDIR"} {
 		if val := os.Getenv(key); val != "" {
 			env = append(env, key+"="+val)
 		}

--- a/pkg/provider/hetzner/cluster_test.go
+++ b/pkg/provider/hetzner/cluster_test.go
@@ -267,6 +267,31 @@ func TestMinimalEnv(t *testing.T) {
 	}
 }
 
+// TestMinimalEnv_NoSSHAuthSock verifies that SSH_AUTH_SOCK is never forwarded to
+// the hetzner-k3s subprocess, even when it is set in the caller's environment.
+//
+// Rationale: cluster.yaml is always generated with use_agent: false, so hetzner-k3s
+// invokes the ssh binary with -i <private_key_path>. However, when SSH_AUTH_SOCK is
+// present in the environment the ssh binary still contacts the agent and offers every
+// loaded key before the explicitly specified identity key. On a freshly created Hetzner
+// node sshd's default MaxAuthTries=6 is exhausted by those agent keys, causing sshd to
+// log "Too many authentication failures" from the deployer's IP. fail2ban then bans the
+// IP via nftables, making the node permanently unreachable for the rest of the deploy.
+func TestMinimalEnv_NoSSHAuthSock(t *testing.T) {
+	t.Setenv("SSH_AUTH_SOCK", "/run/user/1000/gnupg/S.gpg-agent.ssh")
+
+	env := minimalEnv()
+
+	for _, e := range env {
+		if strings.HasPrefix(e, "SSH_AUTH_SOCK=") {
+			t.Errorf("SSH_AUTH_SOCK must not be forwarded to hetzner-k3s: "+
+				"when set, the ssh binary offers all agent keys before the identity key (-i), "+
+				"exhausting sshd MaxAuthTries and triggering a fail2ban ban on the deployer IP. "+
+				"Got: %q", e)
+		}
+	}
+}
+
 func TestMinimalEnv_MissingToken(t *testing.T) {
 	// Unset HETZNER_TOKEN to verify HCLOUD_TOKEN is set but empty
 	t.Setenv("HETZNER_TOKEN", "")


### PR DESCRIPTION
## Summary

Fixes two root causes that prevented `nic deploy` from completing on Hetzner Cloud. See #146 for full diagnosis and technical details.

## Changes

- **binary.go**: Bump hetzner-k3s `v2.4.5` → `v2.4.6` (fixes SSH setup bug in cloud-init)
- **cluster.go**: Remove `SSH_AUTH_SOCK` from `minimalEnv()` (prevents agent keys from exhausting sshd MaxAuthTries and triggering fail2ban IP bans)
- **cluster_test.go**: Add `TestMinimalEnv_NoSSHAuthSock` to prevent regression

## Testing

- [x] `go test ./pkg/provider/hetzner/... -count=1` passes
- [x] `go vet ./pkg/provider/hetzner/...` clean
- [x] Full end-to-end deploy verified on Hetzner Cloud

Closes #146