### PR TITLE
fix(argocd): default KeycloakBasePath to /auth when provider omits it

### DIFF
--- a/pkg/argocd/writer.go
+++ b/pkg/argocd/writer.go
@@ -56,16 +56,27 @@ type TemplateData struct {
 	KeycloakBasePath string
 
 	// Keycloak configuration
-	KeycloakNamespace       string // Namespace where Keycloak is deployed (e.g., "keycloak")
-	KeycloakServiceName     string // Kubernetes service name for Keycloak (e.g., "keycloak-keycloakx-http")
-	KeycloakServiceURL      string // In-cluster URL for Keycloak (e.g., "http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080")
-	KeycloakRealm           string // Keycloak realm name (e.g., "nebari")
-	KeycloakAdminSecretName string // Name of the Kubernetes secret containing Keycloak admin credentials
+	KeycloakNamespace            string // Namespace where Keycloak is deployed (e.g., "keycloak")
+	KeycloakServiceName          string // Kubernetes service name for Keycloak (e.g., "keycloak-keycloakx-http")
+	KeycloakServiceURL           string // In-cluster base URL for the Keycloak service (e.g., "http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080")
+	KeycloakAuthURL              string // Keycloak application root including context path (e.g., "http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/auth")
+	KeycloakIssuerURL            string // External public URL for validating the iss claim in tokens (e.g., "https://keycloak.nebari.example.com/auth")
+	KeycloakRealm                string // Keycloak realm name (e.g., "nebari")
+	KeycloakAdminSecretName      string // Name of the Kubernetes secret containing Keycloak admin credentials
+	KeycloakAdminSecretNamespace string // Namespace of the Kubernetes secret containing Keycloak admin credentials
 }
 
 // NewTemplateData creates TemplateData from NebariConfig and provider InfraSettings.
 func NewTemplateData(cfg *config.NebariConfig, settings provider.InfraSettings) TemplateData {
 	keycloakServiceName := "keycloak-keycloakx-http"
+
+	// All Keycloak deployments managed by NIC use --http-relative-path=/auth
+	// (Keycloak X with context path). Default to "/auth" when the provider does
+	// not set an explicit base path so URLs are always well-formed.
+	keycloakBasePath := settings.KeycloakBasePath
+	if keycloakBasePath == "" {
+		keycloakBasePath = "/auth"
+	}
 
 	data := TemplateData{
 		Domain:                  cfg.Domain,
@@ -73,13 +84,16 @@ func NewTemplateData(cfg *config.NebariConfig, settings provider.InfraSettings) 
 		StorageClass:            settings.StorageClass,
 		MetalLBAddressRange:     settings.MetalLBAddressPool,
 		LoadBalancerAnnotations: settings.LoadBalancerAnnotations,
-		KeycloakBasePath:        settings.KeycloakBasePath,
+		KeycloakBasePath:        keycloakBasePath,
 
-		KeycloakNamespace:       KeycloakDefaultNamespace,
-		KeycloakServiceName:     keycloakServiceName,
-		KeycloakServiceURL:      fmt.Sprintf("http://%s.%s.svc.cluster.local:8080%s", keycloakServiceName, KeycloakDefaultNamespace, settings.KeycloakBasePath),
-		KeycloakRealm:           "nebari",
-		KeycloakAdminSecretName: KeycloakDefaultAdminSecretName,
+		KeycloakNamespace:            KeycloakDefaultNamespace,
+		KeycloakServiceName:          keycloakServiceName,
+		KeycloakServiceURL:           fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", keycloakServiceName, KeycloakDefaultNamespace),
+		KeycloakAuthURL:              fmt.Sprintf("http://%s.%s.svc.cluster.local:8080%s", keycloakServiceName, KeycloakDefaultNamespace, keycloakBasePath),
+		KeycloakIssuerURL:            "", // set after Domain is resolved below
+		KeycloakRealm:                "nebari",
+		KeycloakAdminSecretName:      KeycloakDefaultAdminSecretName,
+		KeycloakAdminSecretNamespace: KeycloakDefaultNamespace,
 	}
 
 	// Set git repository info
@@ -110,6 +124,17 @@ func NewTemplateData(cfg *config.NebariConfig, settings provider.InfraSettings) 
 	// Default domain if not set
 	if data.Domain == "" {
 		data.Domain = "nebari.local"
+	}
+
+	// External Keycloak URL — what Keycloak embeds in the iss claim of tokens.
+	// Clients inside the cluster fetch JWKs via KeycloakAuthURL; they validate
+	// the iss claim against this public URL.
+	// Only set when a real domain is configured. When no domain is provided
+	// (e.g. cloud deployments using a bare LoadBalancer IP), KeycloakIssuerURL
+	// is left empty so KEYCLOAK_ISSUER_URL is not injected and the webapi falls
+	// back to using KEYCLOAK_URL for issuer validation.
+	if cfg.Domain != "" {
+		data.KeycloakIssuerURL = fmt.Sprintf("https://keycloak.%s%s", data.Domain, keycloakBasePath)
 	}
 
 	return data

--- a/pkg/argocd/writer_test.go
+++ b/pkg/argocd/writer_test.go
@@ -113,6 +113,7 @@ func TestNewTemplateData_WithInfraSettings(t *testing.T) {
 			settings: provider.InfraSettings{StorageClass: "gp2"},
 			wantSC:   "gp2",
 			wantLBA:  0,
+			wantKBP:  "/auth", // defaults to /auth when not set by provider
 		},
 		{
 			name: "hetzner with annotations and keycloak path",
@@ -134,6 +135,7 @@ func TestNewTemplateData_WithInfraSettings(t *testing.T) {
 			},
 			wantSC:   "standard",
 			wantMLBA: "192.168.1.100-192.168.1.110",
+			wantKBP:  "/auth", // defaults to /auth when not set by provider
 		},
 	}
 	for _, tt := range tests {
@@ -156,23 +158,25 @@ func TestNewTemplateData_WithInfraSettings(t *testing.T) {
 	}
 }
 
-func TestNewTemplateData_KeycloakServiceURL(t *testing.T) {
+func TestNewTemplateData_KeycloakAuthURL(t *testing.T) {
 	cfg := &config.NebariConfig{Provider: "hetzner", Domain: "test.example.com"}
+
+	// When KeycloakBasePath is explicitly set, it should be honoured.
 	settings := provider.InfraSettings{
 		StorageClass:     "hcloud-volumes",
 		KeycloakBasePath: "/auth",
 	}
 	data := NewTemplateData(cfg, settings)
-
-	if !strings.HasSuffix(data.KeycloakServiceURL, "/auth") {
-		t.Errorf("KeycloakServiceURL = %q, should end with /auth", data.KeycloakServiceURL)
+	if !strings.HasSuffix(data.KeycloakAuthURL, "/auth") {
+		t.Errorf("KeycloakAuthURL = %q, should end with /auth", data.KeycloakAuthURL)
 	}
 
-	// Without base path
+	// When KeycloakBasePath is empty (provider omits it), we default to /auth
+	// because all NIC-managed Keycloak deployments use --http-relative-path=/auth.
 	settings.KeycloakBasePath = ""
 	data = NewTemplateData(cfg, settings)
-	if strings.HasSuffix(data.KeycloakServiceURL, "/auth") {
-		t.Errorf("KeycloakServiceURL = %q, should NOT end with /auth", data.KeycloakServiceURL)
+	if !strings.HasSuffix(data.KeycloakAuthURL, "/auth") {
+		t.Errorf("KeycloakAuthURL = %q, should end with /auth (default)", data.KeycloakAuthURL)
 	}
 }
 


### PR DESCRIPTION
## Problem

All NIC-managed Keycloak deployments use `--http-relative-path=/auth` (Keycloak X context path). The Hetzner provider (and any future provider that doesn't explicitly set `KeycloakBasePath` in its `InfraSettings`) returned `""` for this field, causing `NewTemplateData` to produce malformed URLs:

- `KeycloakAuthURL` → `http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080` (missing `/auth`)
- `KeycloakIssuerURL` → `https://keycloak.example.com` (missing `/auth`)

The oauth2-proxy sidecar received `--oidc-issuer-url=https://keycloak.example.com/realms/nebari` and could not reach Keycloak's OIDC discovery endpoint.

## Fix

In `NewTemplateData`, default `keycloakBasePath` to `"/auth"` when the provider returns an empty string. This is a safe global default — all existing NIC Keycloak deployments use this path.

Also adds the fields introduced by PR #127 (`KeycloakAuthURL`, `KeycloakIssuerURL`, `KeycloakAdminSecretNamespace`) that `feature/hetzner-provider` was missing, and updates tests to assert the new defaulting behaviour.

## Testing

`go test ./pkg/argocd/...` passes. Verified live on a Hetzner cluster where the frontend pod previously received wrong OIDC URLs.