### PR TITLE
Pass KEYCLOAK_EXTERNAL_URL to nebari-operator deployment

### DIFF
--- a/pkg/argocd/templates/manifests/nebari-operator/deployment-patch.yaml
+++ b/pkg/argocd/templates/manifests/nebari-operator/deployment-patch.yaml
@@ -24,6 +24,8 @@ spec:
               value: "{{ .CertificateIssuer }}"
             - name: KEYCLOAK_ISSUER_CONTEXT_PATH
               value: "{{ .KeycloakBasePath }}"
+            - name: KEYCLOAK_EXTERNAL_URL
+              value: "https://keycloak.{{ .Domain }}{{ .KeycloakBasePath }}"
           resources:
             requests:
               cpu: 100m

--- a/pkg/argocd/writer_test.go
+++ b/pkg/argocd/writer_test.go
@@ -330,20 +330,26 @@ func TestOperatorDeploymentPatch_KeycloakContextPath(t *testing.T) {
 	tests := []struct {
 		name             string
 		keycloakBasePath string
+		domain           string
 		wantContextPath  string
 		wantServiceURL   string
+		wantExternalURL  string
 	}{
 		{
 			name:             "empty base path passes empty context path",
 			keycloakBasePath: "",
+			domain:           "test.example.com",
 			wantContextPath:  `value: ""`,
 			wantServiceURL:   "http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080",
+			wantExternalURL:  "https://keycloak.test.example.com",
 		},
 		{
 			name:             "auth base path passes /auth context path",
 			keycloakBasePath: "/auth",
+			domain:           "test.example.com",
 			wantContextPath:  `value: "/auth"`,
 			wantServiceURL:   "http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/auth",
+			wantExternalURL:  "https://keycloak.test.example.com/auth",
 		},
 	}
 
@@ -355,6 +361,7 @@ func TestOperatorDeploymentPatch_KeycloakContextPath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			data := TemplateData{
+				Domain:                  tt.domain,
 				KeycloakBasePath:        tt.keycloakBasePath,
 				KeycloakServiceURL:      fmt.Sprintf("http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080%s", tt.keycloakBasePath),
 				KeycloakNamespace:       "keycloak",
@@ -377,6 +384,12 @@ func TestOperatorDeploymentPatch_KeycloakContextPath(t *testing.T) {
 			}
 			if !strings.Contains(output, tt.wantServiceURL) {
 				t.Errorf("expected service URL %q in rendered template, got:\n%s", tt.wantServiceURL, output)
+			}
+			if !strings.Contains(output, "KEYCLOAK_EXTERNAL_URL") {
+				t.Error("expected KEYCLOAK_EXTERNAL_URL env var in rendered template")
+			}
+			if !strings.Contains(output, tt.wantExternalURL) {
+				t.Errorf("expected external URL %q in rendered template, got:\n%s", tt.wantExternalURL, output)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Closes #195

Adds `KEYCLOAK_EXTERNAL_URL` environment variable to the nebari-operator deployment patch. The value is constructed from the cluster domain and Keycloak base path: `https://keycloak.{domain}{basePath}`.

The operator needs this to write the publicly routable issuer URL into OIDC client Secrets for external consumers (CLI tools using device flow, SPAs using PKCE).

## Test plan

- [ ] `TestOperatorDeploymentPatch_KeycloakContextPath` passes with both empty and `/auth` base paths
- [ ] Rendered template contains `KEYCLOAK_EXTERNAL_URL` with correct value
- [ ] Deploy to cluster and verify operator receives the env var