### PR TITLE
Bump nebari-operator to v0.1.0-alpha.14

### DIFF
--- a/pkg/argocd/templates/manifests/nebari-operator/kustomization.yaml
+++ b/pkg/argocd/templates/manifests/nebari-operator/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 namespace: nebari-operator-system
 
 resources:
-  - https://github.com/nebari-dev/nebari-operator.git/config/default?ref=v0.1.0-alpha.13
+  - https://github.com/nebari-dev/nebari-operator.git/config/default?ref=v0.1.0-alpha.14
 
 images:
   - name: nebari-operator


### PR DESCRIPTION
## Summary

Bumps nebari-operator from v0.1.0-alpha.13 to v0.1.0-alpha.14.

New in this release:
- Device flow client provisioning for CLI/native app authentication (RFC 8628)
- ServiceAccountName field on NebariApp CRD for RBAC scoping
- GetExternalIssuerURL backed by KEYCLOAK_EXTERNAL_URL env var
- Secret RBAC (Role + RoleBinding) scoped to the app's ServiceAccount
- client-id and issuer-url written to OIDC client Secret

See nebari-dev/nebari-operator#85 for details.

## Test plan

- [ ] Deployed and verified on Hetzner cluster
- [ ] NebariApp reconciles with all conditions True
- [ ] Device flow client appears in Keycloak
- [ ] OIDC Secret contains client-id, client-secret, device-client-id, issuer-url
- [ ] RBAC Role/RoleBinding created