### PR TITLE
feat: create EFS StorageClass when EFS is enabled

### DIFF
--- a/examples/aws-config.yaml
+++ b/examples/aws-config.yaml
@@ -77,7 +77,7 @@ cluster:
       performance_mode: generalPurpose # generalPurpose or maxIO
       throughput_mode: bursting # bursting, provisioned, or elastic
       encrypted: true
-      # storage_class_name: efs-sc      # Name for the K8s StorageClass (default: efs-sc)
+      storage_class_name: efs-sc        # Name for the K8s StorageClass (default: efs-sc)
       # kms_key_id: ""                  # Optional: KMS key ARN for encryption
       # provisioned_mbps: 100           # Required if throughput_mode is provisioned
 

--- a/examples/aws-config.yaml
+++ b/examples/aws-config.yaml
@@ -77,7 +77,7 @@ cluster:
       performance_mode: generalPurpose # generalPurpose or maxIO
       throughput_mode: bursting # bursting, provisioned, or elastic
       encrypted: true
-      storage_class_name: efs-sc        # Name for the K8s StorageClass (default: efs-sc)
+      # storage_class_name: efs-sc      # Optional, defaults to efs-sc
       # kms_key_id: ""                  # Optional: KMS key ARN for encryption
       # provisioned_mbps: 100           # Required if throughput_mode is provisioned
 

--- a/pkg/provider/aws/config.go
+++ b/pkg/provider/aws/config.go
@@ -75,7 +75,8 @@ type EFSConfig struct {
 const defaultEFSStorageClassName = "efs-sc"
 
 // EFSStorageClassName returns the StorageClass name for EFS volumes.
-// Defaults to "efs-sc" when not set.
+// Returns the default "efs-sc" when EFS is not configured or when
+// StorageClassName is empty.
 func (c *Config) EFSStorageClassName() string {
 	if c.EFS == nil || c.EFS.StorageClassName == "" {
 		return defaultEFSStorageClassName

--- a/pkg/provider/aws/config.go
+++ b/pkg/provider/aws/config.go
@@ -69,6 +69,18 @@ type EFSConfig struct {
 	ProvisionedThroughput int    `yaml:"provisioned_throughput_mibps,omitempty"`
 	Encrypted             bool   `yaml:"encrypted,omitempty"` // default: true
 	KMSKeyArn             string `yaml:"kms_key_arn,omitempty"`
+	StorageClassName      string `yaml:"storage_class_name,omitempty"` // default: efs-sc
+}
+
+const defaultEFSStorageClassName = "efs-sc"
+
+// EFSStorageClassName returns the StorageClass name for EFS volumes.
+// Defaults to "efs-sc" when not set.
+func (c *Config) EFSStorageClassName() string {
+	if c.EFS == nil || c.EFS.StorageClassName == "" {
+		return defaultEFSStorageClassName
+	}
+	return c.EFS.StorageClassName
 }
 
 type LonghornConfig struct {

--- a/pkg/provider/aws/efs.go
+++ b/pkg/provider/aws/efs.go
@@ -1,0 +1,112 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/nebari-dev/nebari-infrastructure-core/pkg/status"
+)
+
+const (
+	efsCSIProvisioner = "efs.csi.aws.com"
+)
+
+// createEFSStorageClass creates or updates a Kubernetes StorageClass for EFS
+// dynamic provisioning using access points. This requires the EFS CSI driver
+// to be installed on the cluster (handled by the Terraform EKS module).
+func createEFSStorageClass(ctx context.Context, kubeconfigBytes []byte, cfg *Config, efsID string) error {
+	tracer := otel.Tracer("nebari-infrastructure-core")
+	ctx, span := tracer.Start(ctx, "aws.createEFSStorageClass")
+	defer span.End()
+
+	storageClassName := cfg.EFSStorageClassName()
+
+	span.SetAttributes(
+		attribute.String("storage_class_name", storageClassName),
+		attribute.String("efs_id", efsID),
+	)
+
+	client, err := newEFSK8sClient(kubeconfigBytes)
+	if err != nil {
+		span.RecordError(err)
+		return fmt.Errorf("failed to create Kubernetes client: %w", err)
+	}
+
+	return createEFSStorageClassWithClient(ctx, client, cfg, efsID)
+}
+
+// createEFSStorageClassWithClient performs the StorageClass creation using the
+// provided Kubernetes client interface. Separated from createEFSStorageClass
+// to allow testing with fake clients.
+func createEFSStorageClassWithClient(ctx context.Context, client kubernetes.Interface, cfg *Config, efsID string) error {
+	tracer := otel.Tracer("nebari-infrastructure-core")
+	ctx, span := tracer.Start(ctx, "aws.createEFSStorageClassWithClient")
+	defer span.End()
+
+	storageClassName := cfg.EFSStorageClassName()
+
+	status.Send(ctx, status.NewUpdate(status.LevelProgress, "Creating EFS StorageClass").
+		WithResource("efs-storageclass").
+		WithAction("creating").
+		WithMetadata("name", storageClassName))
+
+	reclaimPolicy := corev1.PersistentVolumeReclaimRetain
+	bindingMode := storagev1.VolumeBindingImmediate
+
+	sc := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: storageClassName,
+		},
+		Provisioner: efsCSIProvisioner,
+		Parameters: map[string]string{
+			"provisioningMode": "efs-ap",
+			"fileSystemId":     efsID,
+			"directoryPerms":   "700",
+		},
+		ReclaimPolicy:     &reclaimPolicy,
+		VolumeBindingMode: &bindingMode,
+	}
+
+	existing, err := client.StorageV1().StorageClasses().Get(ctx, storageClassName, metav1.GetOptions{})
+	switch {
+	case k8serrors.IsNotFound(err):
+		if _, err := client.StorageV1().StorageClasses().Create(ctx, sc, metav1.CreateOptions{}); err != nil {
+			span.RecordError(err)
+			return fmt.Errorf("failed to create EFS StorageClass: %w", err)
+		}
+	case err != nil:
+		span.RecordError(err)
+		return fmt.Errorf("failed to get EFS StorageClass: %w", err)
+	default:
+		sc.ResourceVersion = existing.ResourceVersion
+		if _, err := client.StorageV1().StorageClasses().Update(ctx, sc, metav1.UpdateOptions{}); err != nil {
+			span.RecordError(err)
+			return fmt.Errorf("failed to update EFS StorageClass: %w", err)
+		}
+	}
+
+	status.Send(ctx, status.NewUpdate(status.LevelSuccess, "EFS StorageClass ready").
+		WithResource("efs-storageclass").
+		WithAction("ready").
+		WithMetadata("name", storageClassName))
+
+	return nil
+}
+
+// newEFSK8sClient creates a Kubernetes clientset from kubeconfig bytes.
+func newEFSK8sClient(kubeconfigBytes []byte) (*kubernetes.Clientset, error) {
+	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse kubeconfig: %w", err)
+	}
+	return kubernetes.NewForConfig(restConfig)
+}

--- a/pkg/provider/aws/efs.go
+++ b/pkg/provider/aws/efs.go
@@ -11,7 +11,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/nebari-dev/nebari-infrastructure-core/pkg/status"
 )
@@ -35,7 +34,7 @@ func createEFSStorageClass(ctx context.Context, kubeconfigBytes []byte, cfg *Con
 		attribute.String("efs_id", efsID),
 	)
 
-	client, err := newEFSK8sClient(kubeconfigBytes)
+	client, err := newK8sClient(kubeconfigBytes)
 	if err != nil {
 		span.RecordError(err)
 		return fmt.Errorf("failed to create Kubernetes client: %w", err)
@@ -51,6 +50,12 @@ func createEFSStorageClassWithClient(ctx context.Context, client kubernetes.Inte
 	tracer := otel.Tracer("nebari-infrastructure-core")
 	ctx, span := tracer.Start(ctx, "aws.createEFSStorageClassWithClient")
 	defer span.End()
+
+	if efsID == "" {
+		err := fmt.Errorf("efs_id must not be empty")
+		span.RecordError(err)
+		return err
+	}
 
 	storageClassName := cfg.EFSStorageClassName()
 
@@ -87,6 +92,10 @@ func createEFSStorageClassWithClient(ctx context.Context, client kubernetes.Inte
 		span.RecordError(err)
 		return fmt.Errorf("failed to get EFS StorageClass: %w", err)
 	default:
+		status.Send(ctx, status.NewUpdate(status.LevelInfo, "Updating existing EFS StorageClass").
+			WithResource("efs-storageclass").
+			WithAction("updating").
+			WithMetadata("name", storageClassName))
 		sc.ResourceVersion = existing.ResourceVersion
 		if _, err := client.StorageV1().StorageClasses().Update(ctx, sc, metav1.UpdateOptions{}); err != nil {
 			span.RecordError(err)
@@ -100,13 +109,4 @@ func createEFSStorageClassWithClient(ctx context.Context, client kubernetes.Inte
 		WithMetadata("name", storageClassName))
 
 	return nil
-}
-
-// newEFSK8sClient creates a Kubernetes clientset from kubeconfig bytes.
-func newEFSK8sClient(kubeconfigBytes []byte) (*kubernetes.Clientset, error) {
-	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigBytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse kubeconfig: %w", err)
-	}
-	return kubernetes.NewForConfig(restConfig)
 }

--- a/pkg/provider/aws/efs_test.go
+++ b/pkg/provider/aws/efs_test.go
@@ -1,0 +1,160 @@
+package aws
+
+import (
+	"context"
+	"testing"
+
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestEFSStorageClassName(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *Config
+		want   string
+	}{
+		{
+			name:   "nil EFS config returns default",
+			config: &Config{},
+			want:   defaultEFSStorageClassName,
+		},
+		{
+			name: "empty StorageClassName returns default",
+			config: &Config{
+				EFS: &EFSConfig{Enabled: true},
+			},
+			want: defaultEFSStorageClassName,
+		},
+		{
+			name: "custom StorageClassName is returned",
+			config: &Config{
+				EFS: &EFSConfig{
+					Enabled:          true,
+					StorageClassName: "my-efs",
+				},
+			},
+			want: "my-efs",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.config.EFSStorageClassName()
+			if got != tt.want {
+				t.Errorf("EFSStorageClassName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateEFSStorageClassWithClient(t *testing.T) {
+	tests := []struct {
+		name             string
+		config           *Config
+		efsID            string
+		existing         []runtime.Object
+		wantErr          bool
+		wantSCName       string
+		wantProvisioner  string
+		wantFileSystemID string
+	}{
+		{
+			name: "creates StorageClass when it does not exist",
+			config: &Config{
+				EFS: &EFSConfig{Enabled: true},
+			},
+			efsID:            "fs-12345678",
+			existing:         nil,
+			wantErr:          false,
+			wantSCName:       defaultEFSStorageClassName,
+			wantProvisioner:  efsCSIProvisioner,
+			wantFileSystemID: "fs-12345678",
+		},
+		{
+			name: "creates StorageClass with custom name",
+			config: &Config{
+				EFS: &EFSConfig{
+					Enabled:          true,
+					StorageClassName: "custom-efs",
+				},
+			},
+			efsID:            "fs-abcdef01",
+			existing:         nil,
+			wantErr:          false,
+			wantSCName:       "custom-efs",
+			wantProvisioner:  efsCSIProvisioner,
+			wantFileSystemID: "fs-abcdef01",
+		},
+		{
+			name: "updates StorageClass when it already exists",
+			config: &Config{
+				EFS: &EFSConfig{Enabled: true},
+			},
+			efsID: "fs-new-id",
+			existing: []runtime.Object{
+				&storagev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: defaultEFSStorageClassName,
+					},
+					Provisioner: efsCSIProvisioner,
+					Parameters: map[string]string{
+						"fileSystemId": "fs-old-id",
+					},
+				},
+			},
+			wantErr:          false,
+			wantSCName:       defaultEFSStorageClassName,
+			wantProvisioner:  efsCSIProvisioner,
+			wantFileSystemID: "fs-new-id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := fake.NewSimpleClientset(tt.existing...) //nolint:staticcheck
+
+			err := createEFSStorageClassWithClient(context.Background(), client, tt.config, tt.efsID)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			sc, err := client.StorageV1().StorageClasses().Get(context.Background(), tt.wantSCName, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("StorageClass %q not found: %v", tt.wantSCName, err)
+			}
+
+			if sc.Provisioner != tt.wantProvisioner {
+				t.Errorf("Provisioner = %q, want %q", sc.Provisioner, tt.wantProvisioner)
+			}
+
+			if sc.Parameters["fileSystemId"] != tt.wantFileSystemID {
+				t.Errorf("fileSystemId = %q, want %q", sc.Parameters["fileSystemId"], tt.wantFileSystemID)
+			}
+
+			if sc.Parameters["provisioningMode"] != "efs-ap" {
+				t.Errorf("provisioningMode = %q, want %q", sc.Parameters["provisioningMode"], "efs-ap")
+			}
+
+			if sc.Parameters["directoryPerms"] != "700" {
+				t.Errorf("directoryPerms = %q, want %q", sc.Parameters["directoryPerms"], "700")
+			}
+
+			if sc.ReclaimPolicy == nil || string(*sc.ReclaimPolicy) != "Retain" {
+				t.Errorf("ReclaimPolicy = %v, want Retain", sc.ReclaimPolicy)
+			}
+
+			if sc.VolumeBindingMode == nil || string(*sc.VolumeBindingMode) != "Immediate" {
+				t.Errorf("VolumeBindingMode = %v, want Immediate", sc.VolumeBindingMode)
+			}
+		})
+	}
+}

--- a/pkg/provider/aws/efs_test.go
+++ b/pkg/provider/aws/efs_test.go
@@ -89,6 +89,14 @@ func TestCreateEFSStorageClassWithClient(t *testing.T) {
 			wantFileSystemID: "fs-abcdef01",
 		},
 		{
+			name: "rejects empty efsID",
+			config: &Config{
+				EFS: &EFSConfig{Enabled: true},
+			},
+			efsID:   "",
+			wantErr: true,
+		},
+		{
 			name: "updates StorageClass when it already exists",
 			config: &Config{
 				EFS: &EFSConfig{Enabled: true},

--- a/pkg/provider/aws/k8s.go
+++ b/pkg/provider/aws/k8s.go
@@ -1,0 +1,19 @@
+package aws
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// newK8sClient creates a Kubernetes clientset from kubeconfig bytes.
+// Used by post-deploy steps (Longhorn, EFS StorageClass) that need to
+// interact with the cluster after terraform provisioning.
+func newK8sClient(kubeconfigBytes []byte) (*kubernetes.Clientset, error) {
+	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse kubeconfig: %w", err)
+	}
+	return kubernetes.NewForConfig(restConfig)
+}

--- a/pkg/provider/aws/longhorn.go
+++ b/pkg/provider/aws/longhorn.go
@@ -18,7 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/nebari-dev/nebari-infrastructure-core/pkg/helm"
 	"github.com/nebari-dev/nebari-infrastructure-core/pkg/status"
@@ -100,7 +99,7 @@ func ensureISCSI(ctx context.Context, kubeconfigBytes []byte) error {
 		WithResource("iscsi-daemonset").
 		WithAction("installing"))
 
-	client, err := newLonghornK8sClient(kubeconfigBytes)
+	client, err := newK8sClient(kubeconfigBytes)
 	if err != nil {
 		span.RecordError(err)
 		return fmt.Errorf("failed to create Kubernetes client: %w", err)
@@ -222,15 +221,6 @@ func waitForDaemonSetReady(ctx context.Context, client kubernetes.Interface, nam
 			}
 		}
 	}
-}
-
-// newLonghornK8sClient creates a Kubernetes clientset from kubeconfig bytes.
-func newLonghornK8sClient(kubeconfigBytes []byte) (*kubernetes.Clientset, error) {
-	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigBytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse kubeconfig: %w", err)
-	}
-	return kubernetes.NewForConfig(restConfig)
 }
 
 // longhornHelmValues generates the Helm values map for the Longhorn chart

--- a/pkg/provider/aws/provider.go
+++ b/pkg/provider/aws/provider.go
@@ -352,6 +352,12 @@ func (p *Provider) Deploy(ctx context.Context, projectName string, clusterConfig
 			return fmt.Errorf("failed to unmarshal efs_id: %w", err)
 		}
 
+		if efsID == "" {
+			err := fmt.Errorf("efs_id is empty in terraform outputs")
+			span.RecordError(err)
+			return err
+		}
+
 		if err := createEFSStorageClass(ctx, kubeconfigBytes, awsCfg, efsID); err != nil {
 			span.RecordError(err)
 			return fmt.Errorf("failed to create EFS StorageClass: %w", err)

--- a/pkg/provider/aws/provider.go
+++ b/pkg/provider/aws/provider.go
@@ -325,6 +325,39 @@ func (p *Provider) Deploy(ctx context.Context, projectName string, clusterConfig
 		}
 	}
 
+	// Create EFS StorageClass if EFS is enabled
+	if awsCfg.EFS != nil && awsCfg.EFS.Enabled {
+		kubeconfigBytes, err := p.GetKubeconfig(ctx, projectName, clusterConfig)
+		if err != nil {
+			span.RecordError(err)
+			return fmt.Errorf("failed to get kubeconfig for EFS StorageClass: %w", err)
+		}
+
+		outputs, err := tf.Output(ctx)
+		if err != nil {
+			span.RecordError(err)
+			return fmt.Errorf("failed to get terraform outputs for EFS: %w", err)
+		}
+
+		efsIDOutput, ok := outputs["efs_id"]
+		if !ok {
+			err := fmt.Errorf("efs_id not found in terraform outputs")
+			span.RecordError(err)
+			return err
+		}
+
+		var efsID string
+		if err := json.Unmarshal(efsIDOutput.Value, &efsID); err != nil {
+			span.RecordError(err)
+			return fmt.Errorf("failed to unmarshal efs_id: %w", err)
+		}
+
+		if err := createEFSStorageClass(ctx, kubeconfigBytes, awsCfg, efsID); err != nil {
+			span.RecordError(err)
+			return fmt.Errorf("failed to create EFS StorageClass: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -599,19 +632,27 @@ func (p *Provider) Summary(clusterConfig *config.ClusterConfig) map[string]strin
 
 // InfraSettings returns AWS-specific Kubernetes infrastructure settings.
 // StorageClass is "longhorn" when Longhorn is enabled (default), "gp2" otherwise.
+// EFSStorageClass is set when EFS is enabled.
 func (p *Provider) InfraSettings(clusterConfig *config.ClusterConfig) provider.InfraSettings {
 	sc := storageClassLonghorn
+	var efsSC string
 
 	rawCfg := clusterConfig.ProviderConfig()
 	if rawCfg != nil {
 		var awsCfg Config
-		if err := config.UnmarshalProviderConfig(context.Background(), rawCfg, &awsCfg); err == nil && !awsCfg.LonghornEnabled() {
-			sc = storageClassGP2
+		if err := config.UnmarshalProviderConfig(context.Background(), rawCfg, &awsCfg); err == nil {
+			if !awsCfg.LonghornEnabled() {
+				sc = storageClassGP2
+			}
+			if awsCfg.EFS != nil && awsCfg.EFS.Enabled {
+				efsSC = awsCfg.EFSStorageClassName()
+			}
 		}
 	}
 
 	return provider.InfraSettings{
-		StorageClass: sc,
-		NeedsMetalLB: false,
+		StorageClass:    sc,
+		NeedsMetalLB:    false,
+		EFSStorageClass: efsSC,
 	}
 }

--- a/pkg/provider/aws/templates/.terraform.lock.hcl
+++ b/pkg/provider/aws/templates/.terraform.lock.hcl
@@ -2,29 +2,29 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.opentofu.org/hashicorp/aws" {
-  version     = "6.38.0"
+  version     = "6.40.0"
   constraints = ">= 6.0.0, >= 6.12.0, >= 6.23.0, >= 6.28.0"
   hashes = [
-    "h1:1iK6HAkKEVKDwVjos9oaIUSs2BiVKp6kawRSDnvQDdw=",
-    "h1:2Zib+i+MPTE053uE5CKZQ+j1ZJ24Om4FU1N7E9OvjYo=",
-    "h1:7RRhcCUAL2bJKOlOP+morV5t8oLr12RBSWM0Wq8pfJg=",
-    "h1:g1pwp/Y4cDjqrb/WEZBb7CDxGkKXY3WnqXply3JXNXw=",
-    "h1:o5i2OAlbqqBdL/EfIeHTI4HjyZaXGWIi5yS0LZw1Se8=",
-    "zh:0444417955631da2250db30994a21810a5b3388a7c7e9f33243e8b4c4aad45de",
-    "zh:2db1e7f7530d583927668b33c26749f8c4e832963d18cead76de03b2e886517d",
-    "zh:306afc96243ccf07caa2a2a20863ed098d010b645c547f894ee45d729d6278b2",
-    "zh:36cbab61792be4b457ffbdee994b5bdaa81f356c1e5bca5c9591543e376e79b0",
-    "zh:44ec51c2bf9997a8847ef5a3eef1727a2ca73ec0673c21196e860a41ef0c1a06",
-    "zh:49ee8f6a637c2a684082e69d7f2e49ef2ddab63f178124a63f4e6069818f440a",
-    "zh:4a40b799a132c947f5cb32ed85fc516e5615ff649022fe056cdb70d0467a76fb",
-    "zh:4d82a141013391371ef2da8fecd52a95740d07978a1c0908f1964c1411ecc508",
-    "zh:7282205b4f152b08f944a86ae07f36a1b304153c7b923b5e84a7e7d1a75782a0",
-    "zh:78507af5ce09f68d4cb02faefb365dba08dc8cd2746c060d3467ba90c6857115",
-    "zh:8c15164448e87499e3b02b2b03e1e02811de1cc904c667aeb05aa0a0691320fd",
-    "zh:90e955c80ed582759e4fdc22ca4aefaee5175fd6bf8cf0d0e763d3f9fe38aa35",
-    "zh:9ddbc6be09d02ca1b882ba5244b024f76a8042e8bfd8ce3c81d0c25c7220d105",
-    "zh:9f8fc6f328db326bbf04365a1359b76fe1cf39cd890454053bb86db217b37f8f",
-    "zh:eef6dfef9feaac9e9a42af2b9767e23d86d3bae4947b604ba6821b9496d83ed9",
+    "h1:7BnIMXbqx8KNZB4lCrqe0bkRvFXDI/fQ8LV0CxpfMAY=",
+    "h1:9CzXEeN/K/RztuBBUWeGqHsE0xo88y/ivZBfKOFhXEM=",
+    "h1:Rpsh543knmB+/8SSt12/E7eNCrhorTyTsE9hQ3X2/t4=",
+    "h1:WDCDIIeDlPubCYrjPGKuZhi+qtXl2whjDV7c1vqwiU4=",
+    "h1:uI0VJoiZ7nSJu0GnK7kJoEvx8t8/sBUpYH7kp8pYmO0=",
+    "zh:0afa48ff254e87987ab58656c0c9ce408c223df084ca3aa73170eb264c7ffdd8",
+    "zh:1cac5867dde6803c251b2eecfdce870a2f19cb04e09ad28b6d895d3faf8fd853",
+    "zh:2e6c6267dda9a12c6945bbafd4405af6238c3d2617736a2fe6a129ea82b05b81",
+    "zh:38ad3eefbf5a0544b049fcdadec9a1d9cf56f18c9c0cd03659133d635a8e0042",
+    "zh:462a69e653529aff033b22e41332c6b170dfbcd2dac357e0ae40dc84d809a964",
+    "zh:5007c5d67ccd5ef271eb9f512e71a0ef55dae23b6099eec1762a06995d62d4b0",
+    "zh:51778e221c1bf898c5c93acaba0f42dc6b0df14d0982db97d52615061874cae3",
+    "zh:711de3f42d0b26efb5332989e20135079c9a09ee39a5d7e0a2c0e73541991133",
+    "zh:8596ca6540cb2b5bce0de8ad89f030c8ef8088f1128c438f9c362b0657dc89af",
+    "zh:923a632c0995dbcc2cf8678e1e418cc4f3c57a6b3aa0b4cee719b91e7296ef8d",
+    "zh:9839e87b4c3f0112750eeb387f1ec9a982200b67184ccd9482be4b577e1e48f6",
+    "zh:9d994cbaa6a03d78274fd32d4a00b9c97ad202605f11973d738737f20995746c",
+    "zh:a73c5687001b7a79b3cbbcf4a6d4b162cb3a0b73ed322382615b77d3f392f880",
+    "zh:a86a021475165ff3bed8172d846e932cbc047169bb6ee42ce28b41301a7e3988",
+    "zh:c200c757634fb83456e21006281d663c71415845450c5448b9598698aa780e7c",
   ]
 }
 

--- a/pkg/provider/aws/templates/main.tf
+++ b/pkg/provider/aws/templates/main.tf
@@ -1,6 +1,6 @@
 module "eks_cluster" {
   source  = "nebari-dev/eks-cluster/aws"
-  version = "0.1.0"
+  version = "0.2.0"
 
   project_name                             = var.project_name
   tags                                     = var.tags

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -52,6 +52,11 @@ type InfraSettings struct {
 	// Providers running behind a non-standard HTTPS port (e.g., development on 8443)
 	// can override this.
 	HTTPSPort int
+
+	// EFSStorageClass is the name of the EFS-backed StorageClass, if available.
+	// Empty when EFS is not enabled. Software packs can use this for ReadWriteMany
+	// volumes (e.g., shared model storage for LLM serving).
+	EFSStorageClass string
 }
 
 // Provider defines the interface that all cloud providers must implement.


### PR DESCRIPTION
## Summary

Closes #235

- Add `StorageClassName` field to `EFSConfig` (default: `efs-sc`) and create a Kubernetes StorageClass backed by the EFS CSI driver (`efs.csi.aws.com`) after `tf.Apply()` completes
- Expose `EFSStorageClass` in `InfraSettings` so software packs can discover and use it for ReadWriteMany volumes (e.g., shared LLM model weights)
- Follow the existing Longhorn pattern: separate `WithClient` function for testability, idempotent create-or-update, OpenTelemetry instrumented
- Bump terraform-aws-eks-cluster to v0.2.0, which installs the EFS CSI driver addon

## Test plan

- [x] Table-driven unit tests for `EFSStorageClassName()` (nil, empty, custom)
- [x] Table-driven unit tests for `createEFSStorageClassWithClient()` (create, update, custom name)
- [x] All existing tests pass
- [x] `golangci-lint run` clean
- [x] `go vet` clean
- [ ] Manual: deploy with EFS enabled, verify StorageClass created with correct `fileSystemId`
- [ ] Manual: deploy twice, verify idempotent update