### PR TITLE
Fix typo in roadmap link

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ docs/                 Architecture docs, design decisions, ADRs
 
 NIC is under very active development.
 
-Our current roadmap can be found at [2026-02-04-roadmap.md](docs/plans/2026-02-04.roadmap.md). We welcome feedback and
+Our current roadmap can be found at [2026-02-04-roadmap.md](docs/plans/2026-02-04-roadmap.md). We welcome feedback and
 contributions to help shape the future of the project!
 
 ## Documentation


### PR DESCRIPTION
## Closes

No open issue.

## Description

I noticed the link to the roadmap in the readme was broken, because of a dot instead of a dash.

## How to Test

By clicking on the link :)
