### PR TITLE
chore(operator): upgrade nebari-operator to v0.1.0-alpha.17

### DIFF
--- a/pkg/argocd/templates/manifests/nebari-operator/kustomization.yaml
+++ b/pkg/argocd/templates/manifests/nebari-operator/kustomization.yaml
@@ -4,11 +4,11 @@ kind: Kustomization
 namespace: nebari-operator-system
 
 resources:
-  - https://github.com/nebari-dev/nebari-operator.git/config/default?ref=v0.1.0-alpha.16
+  - https://github.com/nebari-dev/nebari-operator.git/config/default?ref=v0.1.0-alpha.17
 images:
   - name: nebari-operator
     newName: quay.io/nebari/nebari-operator
-    newTag: 0.1.0-alpha.16
+    newTag: 0.1.0-alpha.17
 
 patches:
   - path: deployment-patch.yaml


### PR DESCRIPTION
## Summary

Upgrades nebari-operator from `v0.1.0-alpha.16` to `v0.1.0-alpha.17`.

This picks up fixes merged since alpha.16, notably the OIDC issuer URL provisioning for NebariApp resources which was causing `skillsctl` (and potentially other apps relying on OIDC) to crash on startup with `OIDC_ISSUER_URL is required`.

## Changes

### `pkg/argocd/templates/manifests/nebari-operator/kustomization.yaml`
- Bumped kustomize resource ref from `v0.1.0-alpha.16` to `v0.1.0-alpha.17`
- Bumped image tag from `0.1.0-alpha.16` to `0.1.0-alpha.17`

Release: https://github.com/nebari-dev/nebari-operator/releases/tag/v0.1.0-alpha.17
