### PR TITLE
chore: sync priority labels to project Priority field

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -1,17 +1,50 @@
-# .github/workflows/add-to-project.yml
 name: Add to project
 
 on:
   issues:
-    types: [opened]
+    types: [opened, labeled, unlabeled]
   pull_request:
-    types: [opened]
+    types: [opened, labeled, unlabeled]
 
 jobs:
   add-to-project:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1.0.2
+      # https://github.com/actions/add-to-project/releases/tag/v1.0.2
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e
+        id: add
         with:
-          project-url: https://github.com/orgs/nebari-dev/projects/12
+          project-url: ${{ vars.PROJECT_BOARD_URL }}
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+
+      - name: Sync priority field from labels
+        if: steps.add.outputs.itemId != ''
+        env:
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          PROJECT_ID: PVT_kwDOBd3CI84BKoKt
+          FIELD_ID: PVTSSF_lADOBd3CI84BKoKtzg6cHO8
+          ITEM_ID: ${{ steps.add.outputs.itemId }}
+          LABELS: ${{ toJSON(github.event.issue.labels || github.event.pull_request.labels) }}
+        run: |
+          set -uo pipefail
+          PRIORITY=$(echo "$LABELS" | jq -r '.[].name' | grep -oE '^priority: (critical|high|medium|low|icebox)' | head -1 | awk '{print $2}')
+          case "$PRIORITY" in
+            critical) OPT=79628723 ;;
+            high)     OPT=0a877460 ;;
+            medium)   OPT=da944a9c ;;
+            low)      OPT=2772da2e ;;
+            icebox)   OPT=ff56cb75 ;;
+            *)        OPT="" ;;
+          esac
+
+          if [ -n "$OPT" ]; then
+            gh api graphql -f query='
+              mutation($p:ID!,$i:ID!,$f:ID!,$o:String!) {
+                updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$o}}) { projectV2Item { id } }
+              }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$FIELD_ID" -f o="$OPT"
+          else
+            gh api graphql -f query='
+              mutation($p:ID!,$i:ID!,$f:ID!) {
+                clearProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f}) { projectV2Item { id } }
+              }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$FIELD_ID"
+          fi

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   sync:
-    uses: nebari-dev/.github/.github/workflows/sync-project-priority.yaml@feat/sync-project-priority
+    uses: nebari-dev/.github/.github/workflows/sync-project-priority.yaml@main
     with:
       project-id: PVT_kwDOBd3CI84BKoKt
     secrets:

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -7,44 +7,9 @@ on:
     types: [opened, labeled, unlabeled]
 
 jobs:
-  add-to-project:
-    runs-on: ubuntu-latest
-    steps:
-      # https://github.com/actions/add-to-project/releases/tag/v1.0.2
-      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e
-        id: add
-        with:
-          project-url: ${{ vars.PROJECT_BOARD_URL }}
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
-
-      - name: Sync priority field from labels
-        if: steps.add.outputs.itemId != ''
-        env:
-          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
-          PROJECT_ID: PVT_kwDOBd3CI84BKoKt
-          FIELD_ID: PVTSSF_lADOBd3CI84BKoKtzg6cHO8
-          ITEM_ID: ${{ steps.add.outputs.itemId }}
-          LABELS: ${{ toJSON(github.event.issue.labels || github.event.pull_request.labels) }}
-        run: |
-          set -uo pipefail
-          PRIORITY=$(echo "$LABELS" | jq -r '.[].name' | grep -oE '^priority: (critical|high|medium|low|icebox)' | head -1 | awk '{print $2}')
-          case "$PRIORITY" in
-            critical) OPT=79628723 ;;
-            high)     OPT=0a877460 ;;
-            medium)   OPT=da944a9c ;;
-            low)      OPT=2772da2e ;;
-            icebox)   OPT=ff56cb75 ;;
-            *)        OPT="" ;;
-          esac
-
-          if [ -n "$OPT" ]; then
-            gh api graphql -f query='
-              mutation($p:ID!,$i:ID!,$f:ID!,$o:String!) {
-                updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$o}}) { projectV2Item { id } }
-              }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$FIELD_ID" -f o="$OPT"
-          else
-            gh api graphql -f query='
-              mutation($p:ID!,$i:ID!,$f:ID!) {
-                clearProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f}) { projectV2Item { id } }
-              }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$FIELD_ID"
-          fi
+  sync:
+    uses: nebari-dev/.github/.github/workflows/sync-project-priority.yaml@feat/sync-project-priority
+    with:
+      project-id: PVT_kwDOBd3CI84BKoKt
+    secrets:
+      token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
Extends the existing add-to-project workflow to also sync the issue/PR priority label to the `Priority` single-select field on project 12.

## Changes
- Workflow now also triggers on `labeled` and `unlabeled` events
- New step maps `priority: <level>` labels to the project Priority field options (critical/high/medium/low/icebox)
- Clears the field if no priority label is present

## Requirements
- Org secret `ADD_TO_PROJECT_PAT` must have `project: write` scope on the nebari-dev org (the existing token already does)