### PR TITLE
test: demo priority workflow failure without label

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: help build test test-unit test-integration test-integration-local test-coverage test-race clean fmt vet lint install pre-commit release-snapshot localstack-up localstack-down localstack-logs localkind-up localkind-down
 
+# Trivial change to demo priority-label workflow
 # Variables
 BINARY_NAME=nic
 CMD_DIR=./cmd/nic


### PR DESCRIPTION
## Summary
- Trivial Makefile comment to demonstrate that the priority-sync workflow fails when no `priority: *` label is present on a PR.

## Test plan
- [ ] Observe the workflow run fails due to `grep` exit code 1 under `set -eo pipefail`
- [ ] Apply the fix, then verify it passes with no label