### PR TITLE
Bump Nebari Operator version to v0.1.0-alpha.19

### DIFF
--- a/pkg/argocd/templates/manifests/nebari-operator/kustomization.yaml
+++ b/pkg/argocd/templates/manifests/nebari-operator/kustomization.yaml
@@ -4,11 +4,11 @@ kind: Kustomization
 namespace: nebari-operator-system
 
 resources:
-  - https://github.com/nebari-dev/nebari-operator.git/config/default?ref=v0.1.0-alpha.17
+  - https://github.com/nebari-dev/nebari-operator.git/config/default?ref=v0.1.0-alpha.19
 images:
   - name: nebari-operator
     newName: quay.io/nebari/nebari-operator
-    newTag: 0.1.0-alpha.17
+    newTag: 0.1.0-alpha.19
 
 patches:
   - path: deployment-patch.yaml


### PR DESCRIPTION
## Description

This PR updates the Nebari operator version to v0.1.0-alpha.19 to include the changes in https://github.com/nebari-dev/nebari-operator/pull/111

## How to Test

Deploy on any cluster provider and make sure you can access Keycloak.