### PR TITLE
Update nebari-landing chart to v0.1.0-alpha.4

### DIFF
--- a/pkg/argocd/templates/apps/nebari-landingpage.yaml
+++ b/pkg/argocd/templates/apps/nebari-landingpage.yaml
@@ -15,7 +15,7 @@ spec:
 
   source:
     repoURL: https://github.com/nebari-dev/nebari-landing
-    targetRevision: v0.1.0-alpha.3
+    targetRevision: v0.1.0-alpha.4
     path: charts/nebari-landing
     helm:
       releaseName: nebari-landing


### PR DESCRIPTION
## Description

This PR pgrades the nebari-landing helm chart to [v0.1.0-alpha.4](https://github.com/nebari-dev/nebari-landing/releases/tag/v0.1.0-alpha.4)


