### PR TITLE
chore: bump nebari-landing chart to v0.1.0-alpha.5

### DIFF
--- a/pkg/argocd/templates/apps/nebari-landingpage.yaml
+++ b/pkg/argocd/templates/apps/nebari-landingpage.yaml
@@ -25,8 +25,6 @@ spec:
             # External public Keycloak URL - used by the browser for OIDC login.
             url: "{{ .KeycloakIssuerURL }}"
             realm: "{{ .KeycloakRealm }}"
-          oauth2Proxy:
-            oidcIssuerUrl: "{{ .KeycloakIssuerURL }}/realms/{{ .KeycloakRealm }}"
 
         webapi:
           keycloak:

--- a/pkg/argocd/templates/apps/nebari-landingpage.yaml
+++ b/pkg/argocd/templates/apps/nebari-landingpage.yaml
@@ -15,7 +15,7 @@ spec:
 
   source:
     repoURL: https://github.com/nebari-dev/nebari-landing
-    targetRevision: v0.1.0-alpha.4
+    targetRevision: v0.1.0-alpha.5
     path: charts/nebari-landing
     helm:
       releaseName: nebari-landing

--- a/pkg/argocd/templates/apps/nebari-landingpage.yaml
+++ b/pkg/argocd/templates/apps/nebari-landingpage.yaml
@@ -21,12 +21,19 @@ spec:
       releaseName: nebari-landing
       values: |
         frontend:
+          # Pin the image tag to the chart release. The chart defaults to
+          # ":latest", which floats with every upstream release and would
+          # silently change the running image on the next pod restart.
+          image:
+            tag: "0.1.0-alpha.5"
           keycloak:
             # External public Keycloak URL - used by the browser for OIDC login.
             url: "{{ .KeycloakIssuerURL }}"
             realm: "{{ .KeycloakRealm }}"
 
         webapi:
+          image:
+            tag: "0.1.0-alpha.5"
           keycloak:
             # In-cluster URL for JWK fetching (fast, no TLS hop).
             url: "{{ .KeycloakServiceURL }}"

--- a/pkg/argocd/writer.go
+++ b/pkg/argocd/writer.go
@@ -133,15 +133,6 @@ func NewTemplateData(cfg *config.NebariConfig, settings provider.InfraSettings) 
 	// Only set when a real domain is configured. When no domain is provided
 	// (e.g. cloud deployments using a bare LoadBalancer IP), KeycloakIssuerURL
 	// is left empty and KEYCLOAK_ISSUER_URL is not injected into workloads.
-	//
-	// NOTE: The nebari-landingpage template uses KeycloakIssuerURL to construct
-	// oidcIssuerUrl for oauth2-proxy (rendered as "<KeycloakIssuerURL>/realms/<realm>").
-	// If KeycloakIssuerURL is empty this collapses to a relative path like
-	// "/realms/nebari", which oauth2-proxy would reject. In practice this
-	// function defaults Domain to "nebari.local" (see above), so
-	// KeycloakIssuerURL is always populated through normal code paths. However,
-	// if bare-LB-IP deployments (cfg.Domain == "") are ever supported, the
-	// template will need a guard or a separate value for the OIDC issuer URL.
 	if cfg.Domain != "" {
 		data.KeycloakIssuerURL = fmt.Sprintf("https://keycloak.%s%s", data.Domain, settings.KeycloakBasePath)
 	}

--- a/pkg/argocd/writer_test.go
+++ b/pkg/argocd/writer_test.go
@@ -445,22 +445,19 @@ func TestHTTPToHTTPSRedirectRoute(t *testing.T) {
 
 func TestLandingPageTemplate(t *testing.T) {
 	tests := []struct {
-		name              string
-		keycloakBasePath  string
-		wantIssuerURL     string
-		wantOIDCIssuerURL string
+		name             string
+		keycloakBasePath string
+		wantIssuerURL    string
 	}{
 		{
-			name:              "no base path",
-			keycloakBasePath:  "",
-			wantIssuerURL:     "https://keycloak.test.example.com",
-			wantOIDCIssuerURL: "https://keycloak.test.example.com/realms/nebari",
+			name:             "no base path",
+			keycloakBasePath: "",
+			wantIssuerURL:    "https://keycloak.test.example.com",
 		},
 		{
-			name:              "auth base path included in issuer URL",
-			keycloakBasePath:  "/auth",
-			wantIssuerURL:     "https://keycloak.test.example.com/auth",
-			wantOIDCIssuerURL: "https://keycloak.test.example.com/auth/realms/nebari",
+			name:             "auth base path included in issuer URL",
+			keycloakBasePath: "/auth",
+			wantIssuerURL:    "https://keycloak.test.example.com/auth",
 		},
 	}
 
@@ -494,9 +491,6 @@ func TestLandingPageTemplate(t *testing.T) {
 			}
 			if !strings.Contains(output, tt.wantIssuerURL) {
 				t.Errorf("expected issuer URL %q in rendered output, got:\n%s", tt.wantIssuerURL, output)
-			}
-			if !strings.Contains(output, tt.wantOIDCIssuerURL) {
-				t.Errorf("expected OIDC issuer URL %q in rendered output, got:\n%s", tt.wantOIDCIssuerURL, output)
 			}
 			if !strings.Contains(output, data.KeycloakServiceURL) {
 				t.Errorf("expected in-cluster service URL %q in rendered output, got:\n%s", data.KeycloakServiceURL, output)


### PR DESCRIPTION
## Description

Upgrades the nebari-landing helm chart to [v0.1.0-alpha.5](https://github.com/nebari-dev/nebari-landing/releases/tag/v0.1.0-alpha.5).

Full changelog: https://github.com/nebari-dev/nebari-landing/compare/v0.1.0-alpha.4...v0.1.0-alpha.5

## Notes on upstream changes that affect us

The headline change in alpha.5 is **dropping the oauth2-proxy sidecar** in favor of a pure SPA PKCE/S256 flow handled client-side by `keycloak-js` (see [nebari-landing#72](https://github.com/nebari-dev/nebari-landing/pull/72)). The chart no longer renders an `oauth2-proxy` container or a confidential OIDC client; the frontend `Service` now points directly at nginx on port `8080`.

Concrete effects on this Application's values block:

- **Removed** `frontend.oauth2Proxy.oidcIssuerUrl` — the entire `frontend.oauth2Proxy.*` key is gone from the chart in alpha.5, so this override is dead config.
- `frontend.keycloak.{url,realm}` is unchanged — still rendered into `/config.json` for the browser.
- `webapi.*`, `nebariApp.enabled: true`, `httpRoute.*`, and `redis.auth.existingSecret` are unchanged.

## Out of scope (worth a separate look)

- The `NebariApp` template still sets `auth.enabled: true`, so the operator continues to provision the primary (formerly oauth2-proxy) OIDC client even though nothing consumes it anymore. The SPA client provisioned via `spaClient.enabled` is the one actually used.