### PR TITLE
chore: bump nebari-operator to v0.1.0-alpha.20 and nebari-landing to v0.1.0-alpha.5

### DIFF
--- a/pkg/argocd/templates/apps/nebari-landingpage.yaml
+++ b/pkg/argocd/templates/apps/nebari-landingpage.yaml
@@ -15,7 +15,7 @@ spec:
 
   source:
     repoURL: https://github.com/nebari-dev/nebari-landing
-    targetRevision: v0.1.0-alpha.4
+    targetRevision: v0.1.0-alpha.5
     path: charts/nebari-landing
     helm:
       releaseName: nebari-landing

--- a/pkg/argocd/templates/manifests/nebari-operator/kustomization.yaml
+++ b/pkg/argocd/templates/manifests/nebari-operator/kustomization.yaml
@@ -4,11 +4,11 @@ kind: Kustomization
 namespace: nebari-operator-system
 
 resources:
-  - https://github.com/nebari-dev/nebari-operator.git/config/default?ref=v0.1.0-alpha.19
+  - https://github.com/nebari-dev/nebari-operator.git/config/default?ref=v0.1.0-alpha.20
 images:
   - name: nebari-operator
     newName: quay.io/nebari/nebari-operator
-    newTag: 0.1.0-alpha.19
+    newTag: 0.1.0-alpha.20
 
 patches:
   - path: deployment-patch.yaml


### PR DESCRIPTION
## Summary

- `nebari-operator`: `v0.1.0-alpha.19` -> [`v0.1.0-alpha.20`](https://github.com/nebari-dev/nebari-operator/releases/tag/v0.1.0-alpha.20) (released 2026-05-20)
- `nebari-landing`: `v0.1.0-alpha.4` -> [`v0.1.0-alpha.5`](https://github.com/nebari-dev/nebari-landing/releases/tag/v0.1.0-alpha.5) (released 2026-05-12)

Touches:

- `pkg/argocd/templates/manifests/nebari-operator/kustomization.yaml` (operator manifest + image tag)
- `pkg/argocd/templates/apps/nebari-landingpage.yaml` (landing chart `targetRevision`)

## Test plan

- [x] `go test ./pkg/argocd/...` passes locally
- [ ] Deploy and verify operator + landing page come up on a test cluster
- [ ] Confirm Keycloak SSO still works against the landing page