### PR TITLE
feat(aws): make load balancer scheme configurable

### DIFF
--- a/examples/aws-config.yaml
+++ b/examples/aws-config.yaml
@@ -83,6 +83,12 @@ cluster:
     #   enabled: true
     #   # chart_version: "3.2.1"  # optional override; tracks latest v3.x by default
 
+    # Scheme applied to the Gateway's NLB. Defaults to "internet-facing".
+    # Set to "internal" for private-only VPCs (no public subnets / no IGW);
+    # an internet-facing NLB has no public subnets to land in and will hang
+    # the deploy waiting for an LB endpoint.
+    # load_balancer_scheme: internet-facing  # or: internal
+
     # EFS configuration for shared storage (optional)
     # Creates an EFS file system with mount targets in each private subnet
     efs:

--- a/pkg/provider/aws/config.go
+++ b/pkg/provider/aws/config.go
@@ -27,6 +27,22 @@ type Config struct {
 	EFS                       *EFSConfig                       `yaml:"efs,omitempty"`
 	Longhorn                  *longhorn.Config                 `yaml:"longhorn,omitempty"`
 	AWSLoadBalancerController *AWSLoadBalancerControllerConfig `yaml:"aws_load_balancer_controller,omitempty"`
+	LoadBalancerScheme        string                           `yaml:"load_balancer_scheme,omitempty"`
+}
+
+const (
+	LoadBalancerSchemeInternetFacing = "internet-facing"
+	LoadBalancerSchemeInternal       = "internal"
+)
+
+// LoadBalancerSchemeOrDefault returns the configured AWS load balancer scheme,
+// defaulting to "internet-facing" when unset. Values are validated at config
+// load time, so callers can trust the result is one of the supported schemes.
+func (c *Config) LoadBalancerSchemeOrDefault() string {
+	if c.LoadBalancerScheme == "" {
+		return LoadBalancerSchemeInternetFacing
+	}
+	return c.LoadBalancerScheme
 }
 
 type AWSLoadBalancerControllerConfig struct {

--- a/pkg/provider/aws/config.go
+++ b/pkg/provider/aws/config.go
@@ -31,16 +31,21 @@ type Config struct {
 }
 
 const (
-	LoadBalancerSchemeInternetFacing = "internet-facing"
-	LoadBalancerSchemeInternal       = "internal"
+	loadBalancerSchemeInternetFacing = "internet-facing"
+	loadBalancerSchemeInternal       = "internal"
 )
+
+var validLoadBalancerSchemes = []string{
+	loadBalancerSchemeInternetFacing,
+	loadBalancerSchemeInternal,
+}
 
 // LoadBalancerSchemeOrDefault returns the configured AWS load balancer scheme,
 // defaulting to "internet-facing" when unset. Values are validated at config
 // load time, so callers can trust the result is one of the supported schemes.
 func (c *Config) LoadBalancerSchemeOrDefault() string {
 	if c.LoadBalancerScheme == "" {
-		return LoadBalancerSchemeInternetFacing
+		return loadBalancerSchemeInternetFacing
 	}
 	return c.LoadBalancerScheme
 }

--- a/pkg/provider/aws/provider.go
+++ b/pkg/provider/aws/provider.go
@@ -139,11 +139,9 @@ func (p *Provider) Validate(ctx context.Context, projectName string, clusterConf
 	}
 
 	// Validate load_balancer_scheme if specified
-	if awsCfg.LoadBalancerScheme != "" &&
-		awsCfg.LoadBalancerScheme != LoadBalancerSchemeInternetFacing &&
-		awsCfg.LoadBalancerScheme != LoadBalancerSchemeInternal {
-		err := fmt.Errorf("invalid load_balancer_scheme %q: must be %q or %q",
-			awsCfg.LoadBalancerScheme, LoadBalancerSchemeInternetFacing, LoadBalancerSchemeInternal)
+	if awsCfg.LoadBalancerScheme != "" && !contains(validLoadBalancerSchemes, awsCfg.LoadBalancerScheme) {
+		err := fmt.Errorf("invalid load_balancer_scheme %q (must be one of: %v)",
+			awsCfg.LoadBalancerScheme, validLoadBalancerSchemes)
 		span.RecordError(err)
 		return err
 	}
@@ -731,7 +729,7 @@ func (p *Provider) Summary(clusterConfig *config.ClusterConfig) map[string]strin
 func (p *Provider) InfraSettings(clusterConfig *config.ClusterConfig) provider.InfraSettings {
 	sc := longhorn.StorageClassName
 	var efsSC string
-	lbScheme := LoadBalancerSchemeInternetFacing
+	lbScheme := loadBalancerSchemeInternetFacing
 
 	rawCfg := clusterConfig.ProviderConfig()
 	if rawCfg != nil {

--- a/pkg/provider/aws/provider.go
+++ b/pkg/provider/aws/provider.go
@@ -138,6 +138,16 @@ func (p *Provider) Validate(ctx context.Context, projectName string, clusterConf
 		}
 	}
 
+	// Validate load_balancer_scheme if specified
+	if awsCfg.LoadBalancerScheme != "" &&
+		awsCfg.LoadBalancerScheme != LoadBalancerSchemeInternetFacing &&
+		awsCfg.LoadBalancerScheme != LoadBalancerSchemeInternal {
+		err := fmt.Errorf("invalid load_balancer_scheme %q: must be %q or %q",
+			awsCfg.LoadBalancerScheme, LoadBalancerSchemeInternetFacing, LoadBalancerSchemeInternal)
+		span.RecordError(err)
+		return err
+	}
+
 	// Validate node groups
 	if len(awsCfg.NodeGroups) == 0 {
 		err := fmt.Errorf("at least one node group is required")
@@ -714,12 +724,14 @@ func (p *Provider) Summary(clusterConfig *config.ClusterConfig) map[string]strin
 // EFSStorageClass is set when EFS is enabled.
 //
 // LoadBalancerAnnotations route the Gateway's Service to the AWS Load Balancer
-// Controller (type=external) and request a public, IP-targeted NLB. Without
-// aws-load-balancer-scheme=internet-facing, LBC creates an internal NLB by
-// default, which is not reachable from outside the VPC.
+// Controller (type=external) and request an IP-targeted NLB. The
+// aws-load-balancer-scheme annotation defaults to "internet-facing" so the NLB
+// is reachable from outside the VPC; operators with private-only VPCs can
+// override this to "internal" via cluster.aws.load_balancer_scheme.
 func (p *Provider) InfraSettings(clusterConfig *config.ClusterConfig) provider.InfraSettings {
 	sc := longhorn.StorageClassName
 	var efsSC string
+	lbScheme := LoadBalancerSchemeInternetFacing
 
 	rawCfg := clusterConfig.ProviderConfig()
 	if rawCfg != nil {
@@ -731,6 +743,7 @@ func (p *Provider) InfraSettings(clusterConfig *config.ClusterConfig) provider.I
 			if awsCfg.EFS != nil && awsCfg.EFS.Enabled {
 				efsSC = awsCfg.EFSStorageClassName()
 			}
+			lbScheme = awsCfg.LoadBalancerSchemeOrDefault()
 		}
 	}
 
@@ -741,7 +754,7 @@ func (p *Provider) InfraSettings(clusterConfig *config.ClusterConfig) provider.I
 		LoadBalancerAnnotations: map[string]string{
 			"service.beta.kubernetes.io/aws-load-balancer-type":            "external",
 			"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "ip",
-			"service.beta.kubernetes.io/aws-load-balancer-scheme":          "internet-facing",
+			"service.beta.kubernetes.io/aws-load-balancer-scheme":          lbScheme,
 		},
 	}
 }

--- a/pkg/provider/aws/provider_test.go
+++ b/pkg/provider/aws/provider_test.go
@@ -44,13 +44,49 @@ func TestInfraSettings(t *testing.T) {
 		{"KeycloakBasePath is empty", settings.KeycloakBasePath, ""},
 		{"LB type annotation", settings.LoadBalancerAnnotations["service.beta.kubernetes.io/aws-load-balancer-type"], "external"},
 		{"LB target-type annotation", settings.LoadBalancerAnnotations["service.beta.kubernetes.io/aws-load-balancer-nlb-target-type"], "ip"},
-		{"LB scheme annotation", settings.LoadBalancerAnnotations["service.beta.kubernetes.io/aws-load-balancer-scheme"], "internet-facing"},
+		{"LB scheme annotation defaults to internet-facing", settings.LoadBalancerAnnotations["service.beta.kubernetes.io/aws-load-balancer-scheme"], "internet-facing"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.got != tt.want {
 				t.Errorf("got %v, want %v", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInfraSettings_LoadBalancerScheme(t *testing.T) {
+	const schemeKey = "service.beta.kubernetes.io/aws-load-balancer-scheme"
+
+	tests := []struct {
+		name       string
+		providers  map[string]any
+		wantScheme string
+	}{
+		{
+			name:       "default is internet-facing when unset",
+			providers:  map[string]any{"aws": map[string]any{}},
+			wantScheme: "internet-facing",
+		},
+		{
+			name:       "explicit internet-facing",
+			providers:  map[string]any{"aws": map[string]any{"load_balancer_scheme": "internet-facing"}},
+			wantScheme: "internet-facing",
+		},
+		{
+			name:       "explicit internal for private VPC deployments",
+			providers:  map[string]any{"aws": map[string]any{"load_balancer_scheme": "internal"}},
+			wantScheme: "internal",
+		},
+	}
+
+	p := NewProvider()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			settings := p.InfraSettings(&config.ClusterConfig{Providers: tt.providers})
+			if got := settings.LoadBalancerAnnotations[schemeKey]; got != tt.wantScheme {
+				t.Errorf("scheme annotation: got %q, want %q", got, tt.wantScheme)
 			}
 		})
 	}

--- a/pkg/provider/aws/provider_test.go
+++ b/pkg/provider/aws/provider_test.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	"github.com/nebari-dev/nebari-infrastructure-core/pkg/config"
@@ -51,6 +53,44 @@ func TestInfraSettings(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.got != tt.want {
 				t.Errorf("got %v, want %v", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+// TestValidate_LoadBalancerScheme covers the rejection path only. Valid
+// schemes flow through Validate to the AWS credential check, which would
+// require live AWS credentials (or a long IMDS timeout) in this test
+// environment. The default and valid-value paths are exercised by
+// TestInfraSettings and TestInfraSettings_LoadBalancerScheme.
+func TestValidate_LoadBalancerScheme(t *testing.T) {
+	tests := []struct {
+		name   string
+		scheme string
+	}{
+		{name: "typo is rejected", scheme: "internet_facing"},
+		{name: "arbitrary string is rejected", scheme: "public"},
+		{name: "mixed case is rejected", scheme: "Internal"},
+	}
+
+	p := NewProvider()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.ClusterConfig{Providers: map[string]any{"aws": map[string]any{
+				"region":               "us-west-2",
+				"kubernetes_version":   "1.34",
+				"load_balancer_scheme": tt.scheme,
+				"node_groups": map[string]any{
+					"general": map[string]any{"instance": "m5.large"},
+				},
+			}}}
+
+			err := p.Validate(context.Background(), "test-project", cfg)
+			if err == nil {
+				t.Fatalf("expected error for scheme %q, got nil", tt.scheme)
+			}
+			if !strings.Contains(err.Error(), "load_balancer_scheme") {
+				t.Fatalf("expected error to mention load_balancer_scheme, got: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Adds `cluster.aws.load_balancer_scheme` so operators can override the hardcoded `internet-facing` scheme that NIC stamps onto the Gateway's NLB. Defaults preserve existing behavior; valid values are `internet-facing` (default) and `internal`.

Without this, a private-only VPC (no public subnets, common in GovCloud and regulated environments) causes the AWS Load Balancer Controller to look for public subnets it cannot find, and the deploy hangs in the LB endpoint wait.

Closes #305.

## Changes

- `pkg/provider/aws/config.go` - new `LoadBalancerScheme` field + `LoadBalancerSchemeOrDefault()` helper + scheme constants
- `pkg/provider/aws/provider.go` - `InfraSettings()` substitutes the configured value into the scheme annotation; `Validate()` rejects values other than `internal` / `internet-facing` so typos fail fast
- `pkg/provider/aws/provider_test.go` - new table tests covering default + both explicit values + three rejection cases
- `examples/aws-config.yaml` - documents the new optional field with the private-VPC use case

No Terraform module changes needed - the LBC reads the annotation off the Service at runtime.

## Test plan

- [x] Unit tests cover default + both explicit values
- [x] Unit tests cover validation rejection (typo, arbitrary string, mixed case)
- [x] `go test ./...` passes
- [x] `golangci-lint run` clean
- [x] Manual: deploy `dcmcand-305` with `load_balancer_scheme: internal` - confirmed end-to-end:
  - Service annotation: `service.beta.kubernetes.io/aws-load-balancer-scheme: internal`
  - AWS NLB: `Scheme: internal`, `Type: network`
  - LB DNS resolves to RFC1918 only (`10.10.156.89`)
- [ ] Manual: regression check on a normal cluster with the field unset - confirm NLB is still internet-facing (lower priority; the default path is unit-tested and the diff for that path is one constant assignment)
- [ ] Manual (gated on #283 landing): deploy into a fully private VPC built by NIC and confirm the full original failure mode is fixed end-to-end