### PR TITLE
feat(gpu): install NVIDIA GPU Operator via foundational software flow

### DIFF
--- a/examples/aws-config.yaml
+++ b/examples/aws-config.yaml
@@ -131,6 +131,11 @@ cluster:
     # the deploy waiting for an LB endpoint.
     # load_balancer_scheme: internet-facing  # or: internal
 
+    # When a node group sets gpu: true, nic installs the NVIDIA GPU Operator on
+    # the cluster (device plugin only; the AL2023_x86_64_NVIDIA AMI already
+    # ships the driver and container toolkit) so nvidia.com/gpu becomes
+    # schedulable. No extra config is required. See ADR-0006 for the rationale.
+
     # EFS configuration for shared storage (optional)
     # Creates an EFS file system with mount targets in each private subnet
     efs:

--- a/pkg/providers/cluster/aws/config.go
+++ b/pkg/providers/cluster/aws/config.go
@@ -186,6 +186,20 @@ type Taint struct {
 	Effect string `yaml:"effect" json:"effect"` // NO_SCHEDULE, NO_EXECUTE, PREFER_NO_SCHEDULE
 }
 
+// HasGPUNodeGroups reports whether any node group is tagged gpu: true. This is
+// the AWS idiom for "this cluster has GPU hardware": the infra layer already
+// selects the AL2023_x86_64_NVIDIA AMI for these node groups, and the GPU
+// operator install (see gpu_operator.go) keys off it. Exported to match the
+// sibling LonghornEnabled / ClusterAutoscalerEnabled / LoadBalancerControllerEnabled predicates.
+func (c *Config) HasGPUNodeGroups() bool {
+	for _, ng := range c.NodeGroups {
+		if ng.GPU {
+			return true
+		}
+	}
+	return false
+}
+
 // LonghornEnabled returns whether Longhorn distributed block storage should
 // be deployed on this AWS cluster. Defaults to true when the Longhorn block
 // is omitted entirely — Longhorn is the AWS storage default. The shared

--- a/pkg/providers/cluster/aws/gpu_operator.go
+++ b/pkg/providers/cluster/aws/gpu_operator.go
@@ -1,0 +1,257 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/storage/driver"
+
+	"github.com/nebari-dev/nebari-infrastructure-core/pkg/helm"
+	"github.com/nebari-dev/nebari-infrastructure-core/pkg/status"
+)
+
+const (
+	gpuOperatorRepoName  = "nvidia"
+	gpuOperatorRepoURL   = "https://helm.ngc.nvidia.com/nvidia"
+	gpuOperatorChartName = "nvidia/gpu-operator"
+	// gpuOperatorChartVersion pins the upstream NVIDIA gpu-operator Helm chart.
+	// The NGC registry lists this chart with a leading "v" (e.g. "v26.3.2"), so
+	// the prefix is intentional and required for LocateChart to resolve it -
+	// unlike the bare-semver aws-load-balancer-controller chart. Check the NGC
+	// catalog (https://catalog.ngc.nvidia.com/orgs/nvidia/helm-charts/gpu-operator)
+	// for the current version when bumping.
+	gpuOperatorChartVersion   = "v26.3.2"
+	gpuOperatorNamespace      = "gpu-operator"
+	gpuOperatorReleaseName    = "gpu-operator"
+	gpuOperatorInstallTimeout = 10 * time.Minute
+
+	// enabledKey is the gpu-operator chart's per-component on/off value key.
+	enabledKey = "enabled"
+)
+
+// gpuOperatorHelmValues builds the Helm values for the gpu-operator chart.
+//
+// These are the AWS defaults: the EKS-optimized AL2023 NVIDIA AMI already ships
+// the NVIDIA driver and the container toolkit, so the operator only needs to
+// layer on the device plugin (what advertises nvidia.com/gpu). MOFED is
+// disabled so the device plugin doesn't claim all /dev/infiniband/uverbs*
+// devices and conflict with the AWS EFA device plugin on EFA-enabled nodes.
+//
+// When the operator grows to other providers these values will need to vary by
+// provider; for now they are AWS-specific.
+func gpuOperatorHelmValues() map[string]any {
+	return map[string]any{
+		"driver":  map[string]any{enabledKey: false},
+		"toolkit": map[string]any{enabledKey: false},
+		"devicePlugin": map[string]any{
+			enabledKey: true,
+			"env": []any{
+				map[string]any{"name": "MOFED_ENABLED", "value": "false"},
+			},
+		},
+	}
+}
+
+// loadGPUOperatorChart locates and loads the gpu-operator Helm chart.
+func loadGPUOperatorChart(chartPathOptions action.ChartPathOptions) (*chart.Chart, error) {
+	chartPath, err := chartPathOptions.LocateChart(gpuOperatorChartName, cli.New())
+	if err != nil {
+		return nil, fmt.Errorf("failed to locate GPU Operator chart: %w", err)
+	}
+
+	loadedChart, err := loader.Load(chartPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load GPU Operator chart: %w", err)
+	}
+
+	return loadedChart, nil
+}
+
+// installGPUOperator installs or upgrades the NVIDIA GPU Operator via Helm.
+// Safe to call on every deploy; it upgrades an existing release rather than
+// failing. The operator needs no cloud IAM - it manages only in-cluster
+// resources - so unlike the LBC and autoscaler there is no Pod Identity here.
+func installGPUOperator(ctx context.Context, kubeconfigBytes []byte) error {
+	tracer := otel.Tracer("nebari-infrastructure-core")
+	ctx, span := tracer.Start(ctx, "aws.installGPUOperator")
+	defer span.End()
+
+	span.SetAttributes(attribute.String("chart_version", gpuOperatorChartVersion))
+
+	kubeconfigPath, cleanup, err := helm.WriteTempKubeconfig(kubeconfigBytes)
+	if err != nil {
+		span.RecordError(err)
+		return err
+	}
+	defer cleanup()
+
+	if err := helm.AddRepo(ctx, gpuOperatorRepoName, gpuOperatorRepoURL); err != nil {
+		span.RecordError(err)
+		return fmt.Errorf("failed to add nvidia Helm repository: %w", err)
+	}
+
+	actionConfig, err := helm.NewActionConfig(kubeconfigPath, gpuOperatorNamespace)
+	if err != nil {
+		span.RecordError(err)
+		return fmt.Errorf("failed to create Helm action config: %w", err)
+	}
+
+	histClient := action.NewHistory(actionConfig)
+	histClient.Max = 1
+	switch _, err := histClient.Run(gpuOperatorReleaseName); {
+	case err == nil:
+		status.Send(ctx, status.NewUpdate(status.LevelInfo, "GPU Operator already installed, upgrading").
+			WithResource("gpu-operator").
+			WithAction("upgrading"))
+		return upgradeGPUOperator(ctx, actionConfig)
+	case errors.Is(err, driver.ErrReleaseNotFound):
+		// No existing release; fall through to fresh install.
+	default:
+		span.RecordError(err)
+		return fmt.Errorf("failed to query Helm release history for %s: %w", gpuOperatorReleaseName, err)
+	}
+
+	status.Send(ctx, status.NewUpdate(status.LevelProgress, "Installing GPU Operator").
+		WithResource("gpu-operator").
+		WithAction("installing").
+		WithMetadata("chart_version", gpuOperatorChartVersion))
+
+	client := action.NewInstall(actionConfig)
+	client.Namespace = gpuOperatorNamespace
+	client.ReleaseName = gpuOperatorReleaseName
+	client.CreateNamespace = true
+	client.Wait = true
+	client.Timeout = gpuOperatorInstallTimeout
+	client.Version = gpuOperatorChartVersion
+
+	loadedChart, err := loadGPUOperatorChart(client.ChartPathOptions)
+	if err != nil {
+		span.RecordError(err)
+		return err
+	}
+
+	// RunWithContext, not Run: Install.Run builds its own context.Background()
+	// and ignores ours, so a cancellation/timeout during the install window
+	// wouldn't propagate to Helm.
+	release, err := client.RunWithContext(ctx, loadedChart, gpuOperatorHelmValues())
+	if err != nil {
+		span.RecordError(err)
+		return fmt.Errorf("failed to install GPU Operator: %w", err)
+	}
+
+	span.SetAttributes(
+		attribute.String("release_status", string(release.Info.Status)),
+		attribute.Int("release_version", release.Version),
+	)
+
+	status.Send(ctx, status.NewUpdate(status.LevelSuccess, "GPU Operator installed").
+		WithResource("gpu-operator").
+		WithAction("installed").
+		WithMetadata("chart_version", gpuOperatorChartVersion))
+
+	return nil
+}
+
+// upgradeGPUOperator upgrades an existing gpu-operator release.
+func upgradeGPUOperator(ctx context.Context, actionConfig *action.Configuration) error {
+	tracer := otel.Tracer("nebari-infrastructure-core")
+	ctx, span := tracer.Start(ctx, "aws.upgradeGPUOperator")
+	defer span.End()
+
+	span.SetAttributes(attribute.String("chart_version", gpuOperatorChartVersion))
+
+	client := action.NewUpgrade(actionConfig)
+	client.Namespace = gpuOperatorNamespace
+	client.Wait = true
+	client.Timeout = gpuOperatorInstallTimeout
+	client.Version = gpuOperatorChartVersion
+
+	loadedChart, err := loadGPUOperatorChart(client.ChartPathOptions)
+	if err != nil {
+		span.RecordError(err)
+		return err
+	}
+
+	// RunWithContext, not Run: Upgrade.Run ignores the caller's context (it
+	// builds its own context.Background()).
+	release, err := client.RunWithContext(ctx, gpuOperatorReleaseName, loadedChart, gpuOperatorHelmValues())
+	if err != nil {
+		span.RecordError(err)
+		return fmt.Errorf("failed to upgrade GPU Operator: %w", err)
+	}
+
+	span.SetAttributes(
+		attribute.String("release_status", string(release.Info.Status)),
+		attribute.Int("release_version", release.Version),
+	)
+
+	status.Send(ctx, status.NewUpdate(status.LevelSuccess, "GPU Operator upgraded").
+		WithResource("gpu-operator").
+		WithAction("upgraded").
+		WithMetadata("chart_version", gpuOperatorChartVersion))
+
+	return nil
+}
+
+// uninstallGPUOperator removes the gpu-operator Helm release if present. A
+// missing release is not an error. Called during cluster destroy, before tofu
+// tears the cluster down. (Uninstall.Run has no RunWithContext in this Helm
+// version, so it stays on Run.)
+func uninstallGPUOperator(ctx context.Context, kubeconfigBytes []byte) error {
+	tracer := otel.Tracer("nebari-infrastructure-core")
+	ctx, span := tracer.Start(ctx, "aws.uninstallGPUOperator")
+	defer span.End()
+
+	kubeconfigPath, cleanup, err := helm.WriteTempKubeconfig(kubeconfigBytes)
+	if err != nil {
+		span.RecordError(err)
+		return err
+	}
+	defer cleanup()
+
+	actionConfig, err := helm.NewActionConfig(kubeconfigPath, gpuOperatorNamespace)
+	if err != nil {
+		span.RecordError(err)
+		return fmt.Errorf("failed to create Helm action config: %w", err)
+	}
+
+	histClient := action.NewHistory(actionConfig)
+	histClient.Max = 1
+	switch _, err := histClient.Run(gpuOperatorReleaseName); {
+	case errors.Is(err, driver.ErrReleaseNotFound):
+		// Nothing installed; nothing to do.
+		return nil
+	case err != nil:
+		span.RecordError(err)
+		return fmt.Errorf("failed to query Helm release history for %s: %w", gpuOperatorReleaseName, err)
+	}
+
+	status.Send(ctx, status.NewUpdate(status.LevelProgress, "Uninstalling GPU Operator").
+		WithResource("gpu-operator").
+		WithAction("uninstalling"))
+
+	// Wait=false on teardown: this only runs during Destroy, right before tofu
+	// deletes the nodes, and the operator has no cloud resources to drain, so
+	// blocking on graceful removal only adds latency and a failure surface.
+	client := action.NewUninstall(actionConfig)
+	client.Wait = false
+
+	if _, err := client.Run(gpuOperatorReleaseName); err != nil {
+		span.RecordError(err)
+		return fmt.Errorf("failed to uninstall GPU Operator: %w", err)
+	}
+
+	status.Send(ctx, status.NewUpdate(status.LevelSuccess, "GPU Operator uninstalled").
+		WithResource("gpu-operator").
+		WithAction("uninstalled"))
+
+	return nil
+}

--- a/pkg/providers/cluster/aws/gpu_operator_test.go
+++ b/pkg/providers/cluster/aws/gpu_operator_test.go
@@ -1,0 +1,82 @@
+package aws
+
+import "testing"
+
+func TestHasGPUNodeGroups(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want bool
+	}{
+		{
+			name: "empty config",
+			cfg:  Config{},
+			want: false,
+		},
+		{
+			name: "no gpu node groups",
+			cfg:  Config{NodeGroups: map[string]NodeGroup{"user": {Instance: "m7i.xlarge"}}},
+			want: false,
+		},
+		{
+			name: "mixed cpu and gpu node groups",
+			cfg: Config{NodeGroups: map[string]NodeGroup{
+				"user": {Instance: "m7i.xlarge"},
+				"gpu":  {Instance: "g4dn.2xlarge", GPU: true},
+			}},
+			want: true,
+		},
+		{
+			name: "only a gpu node group",
+			cfg: Config{NodeGroups: map[string]NodeGroup{
+				"gpu": {Instance: "g4dn.2xlarge", GPU: true},
+			}},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.HasGPUNodeGroups(); got != tt.want {
+				t.Errorf("HasGPUNodeGroups() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGPUOperatorHelmValues(t *testing.T) {
+	v := gpuOperatorHelmValues()
+
+	// On the EKS NVIDIA AMI the driver and toolkit are preinstalled, so the
+	// operator only layers on the device plugin.
+	componentEnabled := []struct {
+		component string
+		want      bool
+	}{
+		{"driver", false},
+		{"toolkit", false},
+		{"devicePlugin", true},
+	}
+	for _, tt := range componentEnabled {
+		t.Run(tt.component, func(t *testing.T) {
+			m, ok := v[tt.component].(map[string]any)
+			if !ok {
+				t.Fatalf("%s should be a map, got %v", tt.component, v[tt.component])
+			}
+			if m[enabledKey] != tt.want {
+				t.Errorf("%s.enabled = %v, want %v", tt.component, m[enabledKey], tt.want)
+			}
+		})
+	}
+
+	t.Run("MOFED disabled for EFA safety", func(t *testing.T) {
+		dp := v["devicePlugin"].(map[string]any)
+		env, ok := dp["env"].([]any)
+		if !ok || len(env) == 0 {
+			t.Fatalf("devicePlugin.env should set MOFED_ENABLED, got %v", dp["env"])
+		}
+		first, _ := env[0].(map[string]any)
+		if first["name"] != "MOFED_ENABLED" || first["value"] != "false" {
+			t.Errorf("expected MOFED_ENABLED=false, got %v", first)
+		}
+	})
+}

--- a/pkg/providers/cluster/aws/provider.go
+++ b/pkg/providers/cluster/aws/provider.go
@@ -428,6 +428,23 @@ func (p *Provider) Deploy(ctx context.Context, projectName string, clusterConfig
 		}
 	}
 
+	// Install the NVIDIA GPU Operator when the cluster has GPU node groups, so
+	// nvidia.com/gpu is advertised before the GitOps/ArgoCD stage. Gated on the
+	// gpu: true config flag, matching the LBC and cluster-autoscaler; teardown
+	// happens in Destroy. Decision recorded in ADR-0006 (#361).
+	if awsCfg.HasGPUNodeGroups() {
+		kubeconfigBytes, err := p.GetKubeconfig(ctx, projectName, clusterConfig)
+		if err != nil {
+			span.RecordError(err)
+			return fmt.Errorf("failed to get kubeconfig for GPU Operator install: %w", err)
+		}
+
+		if err := installGPUOperator(ctx, kubeconfigBytes); err != nil {
+			span.RecordError(err)
+			return fmt.Errorf("failed to install GPU Operator: %w", err)
+		}
+	}
+
 	// Create EFS StorageClass if EFS is enabled
 	if awsCfg.EFS != nil && awsCfg.EFS.Enabled {
 		kubeconfigBytes, err := p.GetKubeconfig(ctx, projectName, clusterConfig)
@@ -636,6 +653,25 @@ func (p *Provider) Destroy(ctx context.Context, projectName string, clusterConfi
 				}
 				status.Send(ctx, status.NewUpdate(status.LevelWarning, fmt.Sprintf("Longhorn uninstall failed, continuing with --force: %v", err)).
 					WithResource("longhorn").WithAction("uninstalling"))
+			}
+		}
+	}
+
+	// Uninstall the GPU Operator before tofu destroy, gated on the GPU config
+	// flag to mirror the Longhorn block above. The operator has no cloud
+	// resources that can block teardown, so an uninstall failure is never fatal
+	// to the destroy: we warn and continue even without --force (unlike
+	// Longhorn, whose CSI finalizers can wedge node-group deletion). Best-effort.
+	if awsCfg.HasGPUNodeGroups() {
+		kubeconfigBytes, kErr := p.GetKubeconfig(ctx, projectName, clusterConfig)
+		switch {
+		case kErr != nil:
+			status.Send(ctx, status.NewUpdate(status.LevelWarning, fmt.Sprintf("Skipping GPU Operator uninstall: kubeconfig unavailable: %v", kErr)).
+				WithResource("gpu-operator").WithAction("uninstalling"))
+		default:
+			if err := uninstallGPUOperator(ctx, kubeconfigBytes); err != nil {
+				status.Send(ctx, status.NewUpdate(status.LevelWarning, fmt.Sprintf("GPU Operator uninstall failed, continuing: %v", err)).
+					WithResource("gpu-operator").WithAction("uninstalling"))
 			}
 		}
 	}


### PR DESCRIPTION
Installs the NVIDIA GPU Operator on AWS clusters that declare GPU node groups, so `nvidia.com/gpu` is advertised without every software pack shipping its own operator app. Follows the imperative-Helm-in-`Deploy` pattern of the cluster-autoscaler / LBC / Longhorn addons, gated on a config flag rather than a GitOps ArgoCD app. Decision recorded in ADR-0006 (#361).

## What this ships

- **`pkg/providers/cluster/aws/gpu_operator.go`**: `installGPUOperator` / `upgradeGPUOperator` / `uninstallGPUOperator` over Helm (history-check, then install or upgrade). Install and upgrade use `RunWithContext(ctx, ...)` so cancellation/timeouts propagate (the older sibling installers still use `Run`). Values are the AWS NVIDIA-AMI defaults: `driver` and `toolkit` off (the AL2023 NVIDIA AMI ships them), `devicePlugin` on, and `MOFED_ENABLED=false` (AWS's documented workaround for the device-plugin/EFA `uverbs` conflict). Chart pinned to `v26.3.2` from the NGC registry (`helm.ngc.nvidia.com`, which lists it v-prefixed). No IAM/Pod Identity needed; the operator only touches in-cluster resources.
- **`config.go`**: `HasGPUNodeGroups()` predicate (any node group with `gpu: true`).
- **Wiring** (`provider.go`): `Deploy` installs when `HasGPUNodeGroups()` is true, before the ArgoCD/GitOps stage so `nvidia.com/gpu` is advertised by the time GPU workloads sync. `Destroy` uninstalls before `tofu destroy`, gated on the same flag and best-effort (kubeconfig-unavailable warns and skips; an uninstall failure warns and continues without aborting the destroy, since the operator has no cloud resources to drain).
- Tests: `HasGPUNodeGroups` (empty / mixed / only-GPU) and the Helm values (table-driven).

## Scope / what this deliberately does NOT do

Per ADR-0006, this is the hand-rolled interim shape, and the reconcile/prune loop is deferred to the shared `ConditionalCharts` interface in #349. Concretely, this PR does **not** include:

- live-node instance-type detection,
- uninstall-on-disable during `Deploy` (only a full `Destroy` removes the operator),
- any change to `InfraSettings` or a shared GPU config struct.

Gating is purely the `gpu: true` config flag. If a cluster declares GPU node groups the operator is installed; if not, nothing happens.

## Issue #232

Partially resolved by design: the core "`nvidia.com/gpu` isn't advertised" problem is fixed for the declare-`gpu: true`-and-deploy path. Live detection and prune-on-disable are deferred to #349 per ADR-0006.

Device-management docs behind the AWS defaults: [EKS](https://docs.aws.amazon.com/eks/latest/userguide/device-management-nvidia.html).
