### PR TITLE
feat(keycloak): trust org CA bundle for outbound TLS

### DIFF
--- a/pkg/argocd/templates/apps/keycloak.yaml
+++ b/pkg/argocd/templates/apps/keycloak.yaml
@@ -51,6 +51,14 @@ spec:
               value: "https://keycloak.{{ .Domain }}{{ .KeycloakBasePath }}"
             - name: KC_FEATURES
               value: "token-exchange,admin-fine-grained-authz:v1"
+{{- if .TrustManagerEnabled }}
+            # Keycloak 26 (Quarkus) ignores X509_CA_BUNDLE; the org CA is loaded
+            # via the native truststore. KC_TRUSTSTORE_PATHS points at the
+            # trust-manager-projected bundle mounted below and feeds every
+            # outbound TLS call (IdP federation, token introspection).
+            - name: KC_TRUSTSTORE_PATHS
+              value: /etc/nebari/truststore
+{{- end }}
           proxy:
             mode: xforwarded
           livenessProbe: |
@@ -91,6 +99,19 @@ spec:
             limits:
               cpu: 2000m
               memory: 2Gi
+{{- if .TrustManagerEnabled }}
+          extraVolumes: |
+            - name: nebari-trust-bundle
+              configMap:
+                name: nebari-trust-bundle
+                items:
+                  - key: ca-certificates.crt
+                    path: ca-certificates.crt
+          extraVolumeMounts: |
+            - name: nebari-trust-bundle
+              mountPath: /etc/nebari/truststore
+              readOnly: true
+{{- end }}
     # Source 2: Realm setup job (PostSync hook)
     - repoURL: {{ .GitRepoURL }}
       targetRevision: {{ .GitBranch }}

--- a/pkg/argocd/writer_test.go
+++ b/pkg/argocd/writer_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/nebari-dev/nebari-infrastructure-core/pkg/config"
 	"github.com/nebari-dev/nebari-infrastructure-core/pkg/provider"
 )
@@ -322,6 +324,100 @@ func TestKeycloakTemplate_HealthProbes(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestKeycloakTemplate_TrustBundle verifies the org CA bundle is wired into
+// Keycloak only when trust-manager is enabled: the projected ConfigMap is
+// mounted and KC_TRUSTSTORE_PATHS points at it so outbound TLS trusts the org CA.
+func TestKeycloakTemplate_TrustBundle(t *testing.T) {
+	content, err := templates.ReadFile("templates/apps/keycloak.yaml")
+	if err != nil {
+		t.Fatalf("failed to read keycloak template: %v", err)
+	}
+
+	baseData := func() TemplateData {
+		return TemplateData{
+			Domain:                  "test.example.com",
+			KeycloakNamespace:       "keycloak",
+			KeycloakAdminSecretName: "keycloak-admin",
+			GitRepoURL:              "https://github.com/example/repo",
+			GitBranch:               "main",
+		}
+	}
+
+	// helmValues renders the template, confirms the Application manifest is valid
+	// YAML, and returns the inner keycloakx Helm values (also parsed as YAML).
+	helmValues := func(t *testing.T, data TemplateData) (string, map[string]any) {
+		t.Helper()
+		processed, err := processTemplate("apps/keycloak.yaml", content, data)
+		if err != nil {
+			t.Fatalf("processTemplate() error: %v", err)
+		}
+		out := string(processed)
+
+		var app map[string]any
+		if err := yaml.Unmarshal(processed, &app); err != nil {
+			t.Fatalf("rendered Application is not valid YAML: %v\n%s", err, out)
+		}
+		spec, _ := app["spec"].(map[string]any)
+		sources, _ := spec["sources"].([]any)
+		if len(sources) == 0 {
+			t.Fatalf("expected at least one source in:\n%s", out)
+		}
+		src0, _ := sources[0].(map[string]any)
+		helm, _ := src0["helm"].(map[string]any)
+		valuesStr, _ := helm["values"].(string)
+
+		var values map[string]any
+		if err := yaml.Unmarshal([]byte(valuesStr), &values); err != nil {
+			t.Fatalf("keycloakx Helm values are not valid YAML: %v\n%s", err, valuesStr)
+		}
+		return out, values
+	}
+
+	t.Run("mounts bundle and sets truststore path when enabled", func(t *testing.T) {
+		data := baseData()
+		data.TrustManagerEnabled = true
+		data.TrustBundlePEM = testCAPEM
+
+		out, values := helmValues(t, data)
+
+		for _, want := range []string{
+			"KC_TRUSTSTORE_PATHS",
+			"/etc/nebari/truststore",
+			"name: nebari-trust-bundle",
+			"ca-certificates.crt",
+		} {
+			if !strings.Contains(out, want) {
+				t.Errorf("expected rendered template to contain %q, got:\n%s", want, out)
+			}
+		}
+
+		if _, ok := values["extraVolumes"].(string); !ok {
+			t.Errorf("expected extraVolumes string in Helm values, got: %#v", values["extraVolumes"])
+		}
+		if _, ok := values["extraVolumeMounts"].(string); !ok {
+			t.Errorf("expected extraVolumeMounts string in Helm values, got: %#v", values["extraVolumeMounts"])
+		}
+	})
+
+	t.Run("omits bundle wiring when disabled", func(t *testing.T) {
+		out, values := helmValues(t, baseData())
+
+		for _, unwanted := range []string{
+			"KC_TRUSTSTORE_PATHS",
+			"nebari-trust-bundle",
+			"extraVolumes:",
+			"extraVolumeMounts:",
+		} {
+			if strings.Contains(out, unwanted) {
+				t.Errorf("did not expect %q when trust-manager disabled, got:\n%s", unwanted, out)
+			}
+		}
+		if _, ok := values["extraVolumes"]; ok {
+			t.Errorf("did not expect extraVolumes key when disabled, got: %#v", values["extraVolumes"])
+		}
+	})
 }
 
 func TestOperatorDeploymentPatch_KeycloakContextPath(t *testing.T) {


### PR DESCRIPTION
## Summary
Implements https://github.com/nebari-dev/nebari-infrastructure-core/issues/311 (child of https://github.com/nebari-dev/nebari-infrastructure-core/issues/307).

When a top-level `trust_bundle` is configured, Keycloak now trusts the org CA for all outbound TLS (IdP federation, token introspection):
- Mounts the trust-manager-projected `nebari-trust-bundle` ConfigMap (key `ca-certificates.crt`) into the Keycloak pod at `/etc/nebari/truststore`.
- Sets `KC_TRUSTSTORE_PATHS=/etc/nebari/truststore` so Keycloak loads it into its native truststore.

The issue suggested `X509_CA_BUNDLE`, but that is a WildFly-image-only feature; the chart here (`keycloakx` 7.1.6) ships Keycloak 26.5.0 (Quarkus), which ignores it. The native `--truststore-paths` / `KC_TRUSTSTORE_PATHS` mechanism is used instead — the fallback the issue explicitly anticipated.

All wiring is gated on `TrustManagerEnabled`, so deploys without a `trust_bundle` are unchanged.

> Note: stacked on `feat/trust-manager-309` (open PR #346), which adds the trust-manager Bundle/ConfigMap this depends on and is not yet in `main`.

## Test plan
- [x] `go test ./pkg/argocd/` — added `TestKeycloakTemplate_TrustBundle` (asserts mount/env present when enabled, absent when disabled; validates rendered Application + inner Helm values parse as YAML).
- [x] `golangci-lint run ./pkg/argocd/` — clean.
- [x] End-to-end on a local kind cluster:
  - trust-manager projects `nebari-trust-bundle` into the `keycloak` namespace.
  - Keycloak StatefulSet carries `KC_TRUSTSTORE_PATHS` + the volume mount; the CA file (`CN = Test Org Root CA`) is present in-pod.
  - Startup log: `TruststoreBuilder ... Found the following truststore files under .../etc/nebari/truststore`.
  - Outbound TLS to an in-cluster HTTPS endpoint whose cert chains to the org CA → import succeeds (HTTP 200).
  - Control: outbound TLS to an untrusted self-signed endpoint → fails with `PKIX path building failed`, confirming the truststore is doing real work.