### PR TITLE
feat(argocd): trust org CA bundle in the repo-server

### DIFF
--- a/pkg/argocd/foundational.go
+++ b/pkg/argocd/foundational.go
@@ -32,6 +32,9 @@ const (
 	// NebariLandingRedisSecretName is the name of the Kubernetes secret containing Redis password for nebari-landing.
 	NebariLandingRedisSecretName = "nebari-landing-redis" //nolint:gosec // This is a secret name reference, not a credential
 
+	// PartOfLabel is the app.kubernetes.io/part-of label key.
+	PartOfLabel = "app.kubernetes.io/part-of"
+
 	// NebariFoundationalPartOf is the value of the app.kubernetes.io/part-of label for foundational resources.
 	NebariFoundationalPartOf = "nebari-foundational"
 
@@ -287,8 +290,8 @@ func createOrgCAConfigMap(ctx context.Context, client kubernetes.Interface, name
 			Name:      orgCAConfigMapName,
 			Namespace: namespace,
 			Labels: map[string]string{
-				"app.kubernetes.io/part-of":    NebariFoundationalPartOf,
-				"app.kubernetes.io/managed-by": "nebari-infrastructure-core",
+				PartOfLabel:    NebariFoundationalPartOf,
+				ManagedByLabel: NebariManagedByValue,
 			},
 		},
 		Data: map[string]string{orgCAConfigMapKey: orgCABundlePEM},
@@ -371,8 +374,8 @@ func createKeycloakSecrets(ctx context.Context, client kubernetes.Interface, key
 				Name:      "nebari-realm-admin-credentials",
 				Namespace: namespace,
 				Labels: map[string]string{
-					"app.kubernetes.io/part-of": NebariFoundationalPartOf,
-					ManagedByLabel:              NebariManagedByValue,
+					PartOfLabel:    NebariFoundationalPartOf,
+					ManagedByLabel: NebariManagedByValue,
 				},
 			},
 			Type: corev1.SecretTypeOpaque,
@@ -392,8 +395,8 @@ func createKeycloakSecrets(ctx context.Context, client kubernetes.Interface, key
 				Name:      "argocd-oidc-client-secret",
 				Namespace: namespace,
 				Labels: map[string]string{
-					"app.kubernetes.io/part-of": NebariFoundationalPartOf,
-					ManagedByLabel:              NebariManagedByValue,
+					PartOfLabel:    NebariFoundationalPartOf,
+					ManagedByLabel: NebariManagedByValue,
 				},
 			},
 			Type: corev1.SecretTypeOpaque,
@@ -419,8 +422,8 @@ func createLandingPageSecrets(ctx context.Context, client kubernetes.Interface, 
 			Name:      NebariLandingRedisSecretName,
 			Namespace: namespace,
 			Labels: map[string]string{
-				"app.kubernetes.io/part-of": NebariFoundationalPartOf,
-				ManagedByLabel:              NebariManagedByValue,
+				PartOfLabel:    NebariFoundationalPartOf,
+				ManagedByLabel: NebariManagedByValue,
 			},
 		},
 		Type: corev1.SecretTypeOpaque,

--- a/pkg/argocd/foundational.go
+++ b/pkg/argocd/foundational.go
@@ -8,6 +8,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -221,15 +222,20 @@ func createNamespace(ctx context.Context, client kubernetes.Interface, namespace
 	return nil
 }
 
-// createOrUpdateConfigMap creates the ConfigMap, or updates its data when it
-// already exists with different contents. Unlike createSecret (create-only, for
-// generated one-time credentials), an org CA bundle is operator-supplied and
-// rotates, so this upserts to make a changed trust_bundle actually propagate.
+// createOrUpdateConfigMap creates the ConfigMap, or reconciles its data and
+// labels when it already exists with different contents. Unlike createSecret
+// (create-only by design, for generated one-time credentials), an org CA bundle
+// is operator-supplied and rotates, so this upserts to make a changed
+// trust_bundle actually propagate.
 func createOrUpdateConfigMap(ctx context.Context, client kubernetes.Interface, cm *corev1.ConfigMap) error {
 	namespace := cm.Namespace
 	existing, err := client.CoreV1().ConfigMaps(namespace).Get(ctx, cm.Name, metav1.GetOptions{})
 	if err != nil {
-		// Doesn't exist (or unreadable) — create it.
+		if !apierrors.IsNotFound(err) {
+			// A transient/permission error must not be mistaken for "absent" —
+			// otherwise we'd blindly Create and mask the real failure.
+			return fmt.Errorf("failed to get configmap %s: %w", cm.Name, err)
+		}
 		if _, err := client.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{}); err != nil {
 			return fmt.Errorf("failed to create configmap %s: %w", cm.Name, err)
 		}
@@ -240,12 +246,17 @@ func createOrUpdateConfigMap(ctx context.Context, client kubernetes.Interface, c
 		return nil
 	}
 
-	if reflect.DeepEqual(existing.Data, cm.Data) {
-		// Already up to date — nothing to do.
+	// Reconcile both data and our managed labels; no-op when already in sync.
+	if reflect.DeepEqual(existing.Data, cm.Data) && labelsContain(existing.Labels, cm.Labels) {
 		return nil
 	}
-
 	existing.Data = cm.Data
+	if existing.Labels == nil {
+		existing.Labels = map[string]string{}
+	}
+	for k, v := range cm.Labels {
+		existing.Labels[k] = v
+	}
 	if _, err := client.CoreV1().ConfigMaps(namespace).Update(ctx, existing, metav1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("failed to update configmap %s: %w", cm.Name, err)
 	}
@@ -256,7 +267,38 @@ func createOrUpdateConfigMap(ctx context.Context, client kubernetes.Interface, c
 	return nil
 }
 
-// createSecret creates a Kubernetes secret if it doesn't already exist
+// labelsContain reports whether have already includes every key/value in want.
+func labelsContain(have, want map[string]string) bool {
+	for k, v := range want {
+		if have[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// createOrgCAConfigMap upserts the install-time argocd-org-ca ConfigMap holding
+// the operator's org CA, labeled as a foundational resource. It is the org-CA
+// analogue of createKeycloakSecrets — keeping the resource construction beside
+// the other foundational create helpers rather than inline in Install.
+func createOrgCAConfigMap(ctx context.Context, client kubernetes.Interface, namespace, orgCABundlePEM string) error {
+	return createOrUpdateConfigMap(ctx, client, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      orgCAConfigMapName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of":    NebariFoundationalPartOf,
+				"app.kubernetes.io/managed-by": "nebari-infrastructure-core",
+			},
+		},
+		Data: map[string]string{orgCAConfigMapKey: orgCABundlePEM},
+	})
+}
+
+// createSecret creates a Kubernetes secret if it doesn't already exist.
+// Create-only by design: these are generated one-time credentials that must
+// never be overwritten on re-deploy. For operator-supplied data that can rotate
+// (e.g. a CA bundle), use createOrUpdateConfigMap / createOrgCAConfigMap instead.
 func createSecret(ctx context.Context, client kubernetes.Interface, secret *corev1.Secret) error {
 	namespace := secret.Namespace
 	_, err := client.CoreV1().Secrets(namespace).Get(ctx, secret.Name, metav1.GetOptions{})

--- a/pkg/argocd/foundational.go
+++ b/pkg/argocd/foundational.go
@@ -3,6 +3,7 @@ package argocd
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -217,6 +218,41 @@ func createNamespace(ctx context.Context, client kubernetes.Interface, namespace
 		WithAction("created").
 		WithMetadata("namespace", namespace))
 
+	return nil
+}
+
+// createOrUpdateConfigMap creates the ConfigMap, or updates its data when it
+// already exists with different contents. Unlike createSecret (create-only, for
+// generated one-time credentials), an org CA bundle is operator-supplied and
+// rotates, so this upserts to make a changed trust_bundle actually propagate.
+func createOrUpdateConfigMap(ctx context.Context, client kubernetes.Interface, cm *corev1.ConfigMap) error {
+	namespace := cm.Namespace
+	existing, err := client.CoreV1().ConfigMaps(namespace).Get(ctx, cm.Name, metav1.GetOptions{})
+	if err != nil {
+		// Doesn't exist (or unreadable) — create it.
+		if _, err := client.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{}); err != nil {
+			return fmt.Errorf("failed to create configmap %s: %w", cm.Name, err)
+		}
+		status.Send(ctx, status.NewUpdate(status.LevelInfo, fmt.Sprintf("Created ConfigMap %s", cm.Name)).
+			WithResource("configmap").
+			WithAction("created").
+			WithMetadata("configmap_name", cm.Name))
+		return nil
+	}
+
+	if reflect.DeepEqual(existing.Data, cm.Data) {
+		// Already up to date — nothing to do.
+		return nil
+	}
+
+	existing.Data = cm.Data
+	if _, err := client.CoreV1().ConfigMaps(namespace).Update(ctx, existing, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("failed to update configmap %s: %w", cm.Name, err)
+	}
+	status.Send(ctx, status.NewUpdate(status.LevelInfo, fmt.Sprintf("Updated ConfigMap %s", cm.Name)).
+		WithResource("configmap").
+		WithAction("updated").
+		WithMetadata("configmap_name", cm.Name))
 	return nil
 }
 

--- a/pkg/argocd/install.go
+++ b/pkg/argocd/install.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"strconv"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -133,37 +134,17 @@ func Install(ctx context.Context, cfg *config.NebariConfig, clusterProvider clus
 		return fmt.Errorf("failed to create namespace: %w", err)
 	}
 
-	// If an org CA bundle is configured, create the install-time ConfigMap and
-	// wire the repo-server to trust it (combined system+org bundle via env vars).
-	// This must happen before InstallHelm so the values carry the mount and the
-	// ConfigMap exists when the repo-server pod starts.
-	if orgCABundlePEM != "" {
-		cm := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      orgCAConfigMapName,
-				Namespace: argoCDCfg.Namespace,
-				Labels: map[string]string{
-					"app.kubernetes.io/part-of":    NebariFoundationalPartOf,
-					"app.kubernetes.io/managed-by": "nebari-infrastructure-core",
-				},
-			},
-			Data: map[string]string{orgCAConfigMapKey: orgCABundlePEM},
-		}
-		if err := createOrUpdateConfigMap(ctx, k8sClient, cm); err != nil {
-			span.RecordError(err)
-			status.Send(ctx, status.NewUpdate(status.LevelError, "Failed to create org CA ConfigMap").
-				WithResource("argocd").
-				WithAction("ca-config-failed").
-				WithMetadata("error", err.Error()))
-			return fmt.Errorf("create org CA configmap: %w", err)
-		}
-		addOrgCAMount(ctx, argoCDCfg.Values)
-		// Log a fingerprint, never the PEM body, so rotation is observable.
-		status.Send(ctx, status.NewUpdate(status.LevelInfo, "Configured repo-server to trust org CA bundle").
+	// Wire the repo-server to trust the org CA (no-op when none is configured).
+	// Must run before InstallHelm so the Helm values carry the mount and the
+	// backing ConfigMap exists when the repo-server pod starts.
+	span.SetAttributes(attribute.Bool("org_ca_configured", orgCABundlePEM != ""))
+	if err := configureRepoServerCATrust(ctx, k8sClient, argoCDCfg.Namespace, orgCABundlePEM, argoCDCfg.Values); err != nil {
+		span.RecordError(err)
+		status.Send(ctx, status.NewUpdate(status.LevelError, "Failed to configure repo-server CA trust").
 			WithResource("argocd").
-			WithAction("ca-configured").
-			WithMetadata("ca_fingerprint", sha256Fingerprint(orgCABundlePEM)).
-			WithMetadata("ca_bytes", fmt.Sprintf("%d", len(orgCABundlePEM))))
+			WithAction("ca-config-failed").
+			WithMetadata("error", err.Error()))
+		return fmt.Errorf("configure repo-server CA trust: %w", err)
 	}
 
 	// Install Argo CD using Helm
@@ -449,6 +430,29 @@ func addLocalGitopsMount(ctx context.Context, values map[string]any, localPath s
 	repoServer["volumeMounts"] = appendToSlice(repoServer["volumeMounts"], newMount)
 }
 
+// configureRepoServerCATrust upserts the install-time argocd-org-ca ConfigMap
+// and injects the combined-bundle mount into the repo-server Helm values so it
+// trusts the org CA. It is a no-op when orgCABundlePEM is empty. Must be called
+// before InstallHelm so the values carry the mount and the ConfigMap exists when
+// the repo-server pod starts. This is the single seam for org-CA wiring — keep
+// the logic here rather than accreting inline blocks in Install.
+func configureRepoServerCATrust(ctx context.Context, client kubernetes.Interface, namespace, orgCABundlePEM string, values map[string]any) error {
+	if orgCABundlePEM == "" {
+		return nil
+	}
+	if err := createOrgCAConfigMap(ctx, client, namespace, orgCABundlePEM); err != nil {
+		return err
+	}
+	addOrgCAMount(ctx, values)
+	// Log a fingerprint, never the PEM body, so rotation is observable.
+	status.Send(ctx, status.NewUpdate(status.LevelInfo, "Configured repo-server to trust org CA bundle").
+		WithResource("argocd").
+		WithAction("ca-configured").
+		WithMetadata("ca_fingerprint", sha256Fingerprint(orgCABundlePEM)).
+		WithMetadata("ca_bytes", strconv.Itoa(len(orgCABundlePEM))))
+	return nil
+}
+
 // addOrgCAMount wires the ArgoCD repo-server to trust an org CA so it can clone
 // git repos and pull Helm/OCI charts through a TLS-inspecting egress proxy.
 //
@@ -512,6 +516,7 @@ func addOrgCAMount(ctx context.Context, values map[string]any) {
 			"allowPrivilegeEscalation": false,
 			"readOnlyRootFilesystem":   true,
 			"capabilities":             map[string]any{"drop": []any{"ALL"}},
+			"seccompProfile":           map[string]any{"type": "RuntimeDefault"},
 		},
 	})
 

--- a/pkg/argocd/install.go
+++ b/pkg/argocd/install.go
@@ -42,6 +42,15 @@ const (
 	systemCAPath         = "/etc/ssl/certs/ca-certificates.crt"
 	combineCAInitName    = "combine-ca-bundle"
 
+	// orgCAChecksumAnnotation stamps the SHA-256 of the org CA bundle onto the
+	// repo-server pod template. The combined bundle is built by an init container
+	// into an emptyDir, so it is only rebuilt on pod restart; without this, a
+	// rotated trust_bundle updates the argocd-org-ca ConfigMap but the running
+	// pod keeps serving the stale combined bundle. A changed annotation changes
+	// the pod template, so any applied Helm upgrade rolls the pod and the init
+	// container re-runs. See the #364 caveat on when upgrades actually apply.
+	orgCAChecksumAnnotation = "nebari.dev/org-ca-checksum"
+
 	// repoServerImageTpl resolves, via the chart's own tpl pass over
 	// repoServer.initContainers, to the same image the repo-server runs — so the
 	// init container's system CA bundle matches the runtime. This mirrors how the
@@ -443,12 +452,13 @@ func configureRepoServerCATrust(ctx context.Context, client kubernetes.Interface
 	if err := createOrgCAConfigMap(ctx, client, namespace, orgCABundlePEM); err != nil {
 		return err
 	}
-	addOrgCAMount(ctx, values)
+	caFingerprint := sha256Fingerprint(orgCABundlePEM)
+	addOrgCAMount(ctx, values, caFingerprint)
 	// Log a fingerprint, never the PEM body, so rotation is observable.
 	status.Send(ctx, status.NewUpdate(status.LevelInfo, "Configured repo-server to trust org CA bundle").
 		WithResource("argocd").
 		WithAction("ca-configured").
-		WithMetadata("ca_fingerprint", sha256Fingerprint(orgCABundlePEM)).
+		WithMetadata("ca_fingerprint", caFingerprint).
 		WithMetadata("ca_bytes", strconv.Itoa(len(orgCABundlePEM))))
 	return nil
 }
@@ -468,7 +478,7 @@ func configureRepoServerCATrust(ctx context.Context, client kubernetes.Interface
 // The override is additive (system ∪ org), so it does not affect the in-cluster
 // Kubernetes API connection, which client-go validates against the service
 // account's own ca.crt rather than the system store.
-func addOrgCAMount(ctx context.Context, values map[string]any) {
+func addOrgCAMount(ctx context.Context, values map[string]any, caFingerprint string) {
 	tracer := otel.Tracer("nebari-infrastructure-core")
 	_, span := tracer.Start(ctx, "argocd.addOrgCAMount")
 	defer span.End()
@@ -528,6 +538,17 @@ func addOrgCAMount(ctx context.Context, values map[string]any) {
 			"value": combinedCAPath,
 		})
 	}
+
+	// Stamp the bundle checksum on the pod template so a rotated trust_bundle
+	// rolls the repo-server (re-running the combine init container) whenever the
+	// values are actually applied. Merge into any existing podAnnotations rather
+	// than replacing them.
+	podAnnotations, ok := repoServer["podAnnotations"].(map[string]any)
+	if !ok {
+		podAnnotations = map[string]any{}
+		repoServer["podAnnotations"] = podAnnotations
+	}
+	podAnnotations[orgCAChecksumAnnotation] = caFingerprint
 }
 
 // sha256Fingerprint returns a hex SHA-256 of the bundle, for logging without

--- a/pkg/argocd/install.go
+++ b/pkg/argocd/install.go
@@ -57,6 +57,10 @@ const (
 	// chart's built-in copyutil init container picks its image, and avoids pinning
 	// a tag that would drift from defaultChartVersion.
 	repoServerImageTpl = `{{ default .Values.global.image.repository .Values.repoServer.image.repository }}:{{ default (include "argo-cd.defaultTag" .) .Values.repoServer.image.tag }}`
+
+	// Keys reused when building unstructured Helm-value / pod-spec map fragments.
+	keyType      = "type"
+	keyMountPath = "mountPath"
 )
 
 // Install installs Argo CD on a Kubernetes cluster
@@ -424,17 +428,17 @@ func addLocalGitopsMount(ctx context.Context, values map[string]any, localPath s
 	newVolume := map[string]any{
 		"name": localGitopsVolumeName,
 		"hostPath": map[string]any{
-			"path": localPath,
-			"type": "Directory",
+			"path":  localPath,
+			keyType: "Directory",
 		},
 	}
 	repoServer["volumes"] = appendToSlice(repoServer["volumes"], newVolume)
 
 	// Append to existing volumeMounts
 	newMount := map[string]any{
-		"name":      localGitopsVolumeName,
-		"mountPath": localPath,
-		"readOnly":  true,
+		"name":       localGitopsVolumeName,
+		keyMountPath: localPath,
+		"readOnly":   true,
 	}
 	repoServer["volumeMounts"] = appendToSlice(repoServer["volumeMounts"], newMount)
 }
@@ -502,9 +506,9 @@ func addOrgCAMount(ctx context.Context, values map[string]any, caFingerprint str
 
 	// The repo-server container reads the combined bundle (read-only).
 	repoServer["volumeMounts"] = appendToSlice(repoServer["volumeMounts"], map[string]any{
-		"name":      combinedCAVolumeName,
-		"mountPath": combinedCADir,
-		"readOnly":  true,
+		"name":       combinedCAVolumeName,
+		keyMountPath: combinedCADir,
+		"readOnly":   true,
 	})
 
 	// Init container builds system-CA ∪ org-CA. The `cat` tolerates a missing
@@ -518,15 +522,15 @@ func addOrgCAMount(ctx context.Context, values map[string]any, caFingerprint str
 		"image":   repoServerImageTpl,
 		"command": []any{"sh", "-c", combineScript},
 		"volumeMounts": []any{
-			map[string]any{"name": orgCAVolumeName, "mountPath": orgCAMountDir, "readOnly": true},
-			map[string]any{"name": combinedCAVolumeName, "mountPath": combinedCADir},
+			map[string]any{"name": orgCAVolumeName, keyMountPath: orgCAMountDir, "readOnly": true},
+			map[string]any{"name": combinedCAVolumeName, keyMountPath: combinedCADir},
 		},
 		"securityContext": map[string]any{
 			"runAsNonRoot":             true,
 			"allowPrivilegeEscalation": false,
 			"readOnlyRootFilesystem":   true,
 			"capabilities":             map[string]any{"drop": []any{"ALL"}},
-			"seccompProfile":           map[string]any{"type": "RuntimeDefault"},
+			"seccompProfile":           map[string]any{keyType: "RuntimeDefault"},
 		},
 	})
 

--- a/pkg/argocd/install.go
+++ b/pkg/argocd/install.go
@@ -2,6 +2,8 @@ package argocd
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -21,13 +23,39 @@ import (
 const (
 	argoCDServerDeployment = "argocd-server"
 	localGitopsVolumeName  = "local-gitops"
+
+	// orgCAConfigMapName is the install-time ConfigMap (in the argocd namespace)
+	// that holds the operator's org CA. The repo-server mounts it. It is created
+	// by NIC at install time rather than sourced from trust-manager's projected
+	// bundle on purpose: the repo-server is the component that pulls trust-manager
+	// (and every other chart) through the inspecting proxy, so it needs to trust
+	// the org CA *before* trust-manager exists. See #310.
+	orgCAConfigMapName = "argocd-org-ca"
+	orgCAConfigMapKey  = "ca.crt"
+
+	orgCAVolumeName      = "org-ca"
+	combinedCAVolumeName = "combined-ca"
+	orgCAMountDir        = "/etc/nebari/org-ca"
+	combinedCADir        = "/etc/ssl/certs-combined"
+	combinedCAPath       = "/etc/ssl/certs-combined/ca-bundle.crt"
+	systemCAPath         = "/etc/ssl/certs/ca-certificates.crt"
+	combineCAInitName    = "combine-ca-bundle"
+
+	// repoServerImageTpl resolves, via the chart's own tpl pass over
+	// repoServer.initContainers, to the same image the repo-server runs — so the
+	// init container's system CA bundle matches the runtime. This mirrors how the
+	// chart's built-in copyutil init container picks its image, and avoids pinning
+	// a tag that would drift from defaultChartVersion.
+	repoServerImageTpl = `{{ default .Values.global.image.repository .Values.repoServer.image.repository }}:{{ default (include "argo-cd.defaultTag" .) .Values.repoServer.image.tag }}`
 )
 
 // Install installs Argo CD on a Kubernetes cluster
 // This is the main entry point called from cmd/nic/deploy.go
 // If gitConfig is a local file:// path, the directory is mounted into the repo-server pod.
 // gitConfig may be nil when no GitOps repository is configured.
-func Install(ctx context.Context, cfg *config.NebariConfig, clusterProvider cluster.Provider, gitConfig *git.Config, argoCDCfg Config) error {
+// orgCABundlePEM, when non-empty, is the operator's org CA: it is written to the
+// argocd-org-ca ConfigMap and the repo-server is wired to trust it (see addOrgCAMount).
+func Install(ctx context.Context, cfg *config.NebariConfig, clusterProvider cluster.Provider, gitConfig *git.Config, orgCABundlePEM string, argoCDCfg Config) error {
 	tracer := otel.Tracer("nebari-infrastructure-core")
 	ctx, span := tracer.Start(ctx, "argocd.Install")
 	defer span.End()
@@ -103,6 +131,39 @@ func Install(ctx context.Context, cfg *config.NebariConfig, clusterProvider clus
 			WithAction("create-failed").
 			WithMetadata("error", err.Error()))
 		return fmt.Errorf("failed to create namespace: %w", err)
+	}
+
+	// If an org CA bundle is configured, create the install-time ConfigMap and
+	// wire the repo-server to trust it (combined system+org bundle via env vars).
+	// This must happen before InstallHelm so the values carry the mount and the
+	// ConfigMap exists when the repo-server pod starts.
+	if orgCABundlePEM != "" {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      orgCAConfigMapName,
+				Namespace: argoCDCfg.Namespace,
+				Labels: map[string]string{
+					"app.kubernetes.io/part-of":    NebariFoundationalPartOf,
+					"app.kubernetes.io/managed-by": "nebari-infrastructure-core",
+				},
+			},
+			Data: map[string]string{orgCAConfigMapKey: orgCABundlePEM},
+		}
+		if err := createOrUpdateConfigMap(ctx, k8sClient, cm); err != nil {
+			span.RecordError(err)
+			status.Send(ctx, status.NewUpdate(status.LevelError, "Failed to create org CA ConfigMap").
+				WithResource("argocd").
+				WithAction("ca-config-failed").
+				WithMetadata("error", err.Error()))
+			return fmt.Errorf("create org CA configmap: %w", err)
+		}
+		addOrgCAMount(ctx, argoCDCfg.Values)
+		// Log a fingerprint, never the PEM body, so rotation is observable.
+		status.Send(ctx, status.NewUpdate(status.LevelInfo, "Configured repo-server to trust org CA bundle").
+			WithResource("argocd").
+			WithAction("ca-configured").
+			WithMetadata("ca_fingerprint", sha256Fingerprint(orgCABundlePEM)).
+			WithMetadata("ca_bytes", fmt.Sprintf("%d", len(orgCABundlePEM))))
 	}
 
 	// Install Argo CD using Helm
@@ -386,6 +447,89 @@ func addLocalGitopsMount(ctx context.Context, values map[string]any, localPath s
 		"readOnly":  true,
 	}
 	repoServer["volumeMounts"] = appendToSlice(repoServer["volumeMounts"], newMount)
+}
+
+// addOrgCAMount wires the ArgoCD repo-server to trust an org CA so it can clone
+// git repos and pull Helm/OCI charts through a TLS-inspecting egress proxy.
+//
+// An init container concatenates the image's system CA bundle with the org CA
+// (mounted from the argocd-org-ca ConfigMap) into a shared emptyDir, and the
+// repo-server's SSL_CERT_FILE / GIT_SSL_CAINFO / CURL_CA_BUNDLE point at the
+// combined file. All three are needed: git ignores SSL_CERT_FILE alone.
+//
+// We deliberately do NOT populate argocd-tls-certs-cm: entries there make Argo
+// pass --ca-file to git/helm, which *replaces* (not augments) the system trust
+// pool and breaks cross-host redirects (e.g. a chart repo redirecting to GitHub).
+//
+// The override is additive (system ∪ org), so it does not affect the in-cluster
+// Kubernetes API connection, which client-go validates against the service
+// account's own ca.crt rather than the system store.
+func addOrgCAMount(ctx context.Context, values map[string]any) {
+	tracer := otel.Tracer("nebari-infrastructure-core")
+	_, span := tracer.Start(ctx, "argocd.addOrgCAMount")
+	defer span.End()
+
+	repoServer, ok := values["repoServer"].(map[string]any)
+	if !ok {
+		repoServer = map[string]any{}
+		values["repoServer"] = repoServer
+	}
+
+	// Volumes: the org CA ConfigMap (read by the init container) and a shared
+	// emptyDir holding the combined bundle (written by init, read by repo-server).
+	repoServer["volumes"] = appendToSlice(repoServer["volumes"], map[string]any{
+		"name":      orgCAVolumeName,
+		"configMap": map[string]any{"name": orgCAConfigMapName},
+	})
+	repoServer["volumes"] = appendToSlice(repoServer["volumes"], map[string]any{
+		"name":     combinedCAVolumeName,
+		"emptyDir": map[string]any{},
+	})
+
+	// The repo-server container reads the combined bundle (read-only).
+	repoServer["volumeMounts"] = appendToSlice(repoServer["volumeMounts"], map[string]any{
+		"name":      combinedCAVolumeName,
+		"mountPath": combinedCADir,
+		"readOnly":  true,
+	})
+
+	// Init container builds system-CA ∪ org-CA. The `cat` tolerates a missing
+	// system file (slim base image) rather than crash-looping the pod; the org CA
+	// is our own mounted ConfigMap, so its absence is a real error.
+	combineScript := fmt.Sprintf(
+		"set -eu; : > %[1]s; if [ -f %[2]s ]; then cat %[2]s >> %[1]s; fi; cat %[3]s/%[4]s >> %[1]s",
+		combinedCAPath, systemCAPath, orgCAMountDir, orgCAConfigMapKey)
+	repoServer["initContainers"] = appendToSlice(repoServer["initContainers"], map[string]any{
+		"name":    combineCAInitName,
+		"image":   repoServerImageTpl,
+		"command": []any{"sh", "-c", combineScript},
+		"volumeMounts": []any{
+			map[string]any{"name": orgCAVolumeName, "mountPath": orgCAMountDir, "readOnly": true},
+			map[string]any{"name": combinedCAVolumeName, "mountPath": combinedCADir},
+		},
+		"securityContext": map[string]any{
+			"runAsNonRoot":             true,
+			"allowPrivilegeEscalation": false,
+			"readOnlyRootFilesystem":   true,
+			"capabilities":             map[string]any{"drop": []any{"ALL"}},
+		},
+	})
+
+	// Point the repo-server's TLS clients at the combined bundle. git uses
+	// GIT_SSL_CAINFO, curl/helm use CURL_CA_BUNDLE, Go uses SSL_CERT_FILE.
+	for _, name := range []string{"SSL_CERT_FILE", "GIT_SSL_CAINFO", "CURL_CA_BUNDLE"} {
+		repoServer["env"] = appendToSlice(repoServer["env"], map[string]any{
+			"name":  name,
+			"value": combinedCAPath,
+		})
+	}
+}
+
+// sha256Fingerprint returns a hex SHA-256 of the bundle, for logging without
+// echoing the certificate body.
+func sha256Fingerprint(pem string) string {
+	sum := sha256.Sum256([]byte(pem))
+	return hex.EncodeToString(sum[:])
 }
 
 // appendToSlice appends a new item to an existing slice, handling both

--- a/pkg/argocd/orgca_test.go
+++ b/pkg/argocd/orgca_test.go
@@ -152,15 +152,60 @@ func TestCreateOrUpdateConfigMap(t *testing.T) {
 		}
 	})
 
-	t.Run("no-op when data unchanged", func(t *testing.T) {
+	t.Run("no-op when data unchanged issues no update", func(t *testing.T) {
 		existing := newCM("CA-A")
 		client := fake.NewSimpleClientset(existing) //nolint:staticcheck // SA1019: NewSimpleClientset is deprecated but still functional for tests
 		if err := createOrUpdateConfigMap(context.Background(), client, newCM("CA-A")); err != nil {
 			t.Fatalf("createOrUpdateConfigMap: %v", err)
 		}
-		got, _ := client.CoreV1().ConfigMaps(ns).Get(context.Background(), "argocd-org-ca", metav1.GetOptions{})
-		if got.Data["ca.crt"] != "CA-A" {
-			t.Errorf("data = %q, want CA-A", got.Data["ca.crt"])
+		// Prove the DeepEqual early-return fired: a write would defeat the no-op.
+		for _, a := range client.Actions() {
+			if a.GetVerb() == "update" || a.GetVerb() == "create" {
+				t.Errorf("unexpected %s action on no-op", a.GetVerb())
+			}
+		}
+	})
+}
+
+func TestConfigureRepoServerCATrust(t *testing.T) {
+	const ns = "argocd"
+
+	t.Run("no-op when bundle empty", func(t *testing.T) {
+		client := fake.NewSimpleClientset() //nolint:staticcheck // SA1019: NewSimpleClientset is deprecated but still functional for tests
+		values := map[string]any{}
+		if err := configureRepoServerCATrust(context.Background(), client, ns, "", values); err != nil {
+			t.Fatalf("configureRepoServerCATrust: %v", err)
+		}
+		if _, ok := values["repoServer"]; ok {
+			t.Error("repoServer values should be untouched when no bundle is configured")
+		}
+		if _, err := client.CoreV1().ConfigMaps(ns).Get(context.Background(), "argocd-org-ca", metav1.GetOptions{}); err == nil {
+			t.Error("argocd-org-ca ConfigMap should not be created when no bundle is configured")
+		}
+	})
+
+	t.Run("creates labeled ConfigMap and wires values", func(t *testing.T) {
+		client := fake.NewSimpleClientset() //nolint:staticcheck // SA1019: NewSimpleClientset is deprecated but still functional for tests
+		values := map[string]any{}
+		if err := configureRepoServerCATrust(context.Background(), client, ns, "ORG-CA-PEM", values); err != nil {
+			t.Fatalf("configureRepoServerCATrust: %v", err)
+		}
+
+		cm, err := client.CoreV1().ConfigMaps(ns).Get(context.Background(), "argocd-org-ca", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected argocd-org-ca to exist: %v", err)
+		}
+		if cm.Data["ca.crt"] != "ORG-CA-PEM" {
+			t.Errorf("ca.crt = %q, want ORG-CA-PEM", cm.Data["ca.crt"])
+		}
+		if cm.Labels["app.kubernetes.io/part-of"] != "nebari-foundational" ||
+			cm.Labels["app.kubernetes.io/managed-by"] != "nebari-infrastructure-core" {
+			t.Errorf("foundational labels missing/wrong: %v", cm.Labels)
+		}
+
+		repoServer, ok := values["repoServer"].(map[string]any)
+		if !ok || entryByName(t, repoServer["volumes"], "org-ca") == nil {
+			t.Error("repoServer values were not wired with the org-ca mount")
 		}
 	})
 }

--- a/pkg/argocd/orgca_test.go
+++ b/pkg/argocd/orgca_test.go
@@ -27,7 +27,7 @@ func entryByName(t *testing.T, list any, name string) map[string]any {
 
 func TestAddOrgCAMount(t *testing.T) {
 	values := map[string]any{}
-	addOrgCAMount(context.Background(), values)
+	addOrgCAMount(context.Background(), values, "test-fingerprint")
 
 	repoServer, ok := values["repoServer"].(map[string]any)
 	if !ok {
@@ -95,16 +95,26 @@ func TestAddOrgCAMount(t *testing.T) {
 			t.Errorf("env %s = %v, want %s", name, env[name], wantPath)
 		}
 	}
+
+	// Rotation: the org CA fingerprint is stamped on the pod template so an
+	// applied upgrade rolls the repo-server and re-runs the combine init container.
+	pa, ok := repoServer["podAnnotations"].(map[string]any)
+	if !ok || pa["nebari.dev/org-ca-checksum"] != "test-fingerprint" {
+		t.Errorf("podAnnotations = %v, want nebari.dev/org-ca-checksum=test-fingerprint", repoServer["podAnnotations"])
+	}
 }
 
 // addOrgCAMount must preserve existing repoServer keys and coexist with the
 // local-gitops mount (both append to repoServer.volumes).
 func TestAddOrgCAMountPreservesAndCoexists(t *testing.T) {
 	values := map[string]any{
-		"repoServer": map[string]any{"replicas": 2},
+		"repoServer": map[string]any{
+			"replicas":       2,
+			"podAnnotations": map[string]any{"existing/annotation": "keep"},
+		},
 	}
 	addLocalGitopsMount(context.Background(), values, "/tmp/gitops")
-	addOrgCAMount(context.Background(), values)
+	addOrgCAMount(context.Background(), values, "fp")
 
 	repoServer := values["repoServer"].(map[string]any)
 	if repoServer["replicas"] != 2 {
@@ -114,6 +124,12 @@ func TestAddOrgCAMountPreservesAndCoexists(t *testing.T) {
 		if entryByName(t, repoServer["volumes"], name) == nil {
 			t.Errorf("volume %q missing after both mounts applied", name)
 		}
+	}
+
+	// Existing podAnnotations are preserved and the checksum is merged in.
+	pa := repoServer["podAnnotations"].(map[string]any)
+	if pa["existing/annotation"] != "keep" || pa["nebari.dev/org-ca-checksum"] != "fp" {
+		t.Errorf("podAnnotations not merged: %v", pa)
 	}
 }
 
@@ -206,6 +222,10 @@ func TestConfigureRepoServerCATrust(t *testing.T) {
 		repoServer, ok := values["repoServer"].(map[string]any)
 		if !ok || entryByName(t, repoServer["volumes"], "org-ca") == nil {
 			t.Error("repoServer values were not wired with the org-ca mount")
+		}
+		// The full path also stamps a (non-empty) checksum annotation for rotation.
+		if pa, ok := repoServer["podAnnotations"].(map[string]any); !ok || pa["nebari.dev/org-ca-checksum"] == nil || pa["nebari.dev/org-ca-checksum"] == "" {
+			t.Errorf("pod checksum annotation not wired end-to-end: %v", repoServer["podAnnotations"])
 		}
 	})
 }

--- a/pkg/argocd/orgca_test.go
+++ b/pkg/argocd/orgca_test.go
@@ -1,0 +1,166 @@
+package argocd
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// entryByName finds a volume / volumeMount / env entry by its "name" key.
+func entryByName(t *testing.T, list any, name string) map[string]any {
+	t.Helper()
+	items, ok := list.([]map[string]any)
+	if !ok {
+		t.Fatalf("expected []map[string]any, got %T", list)
+	}
+	for _, it := range items {
+		if it["name"] == name {
+			return it
+		}
+	}
+	return nil
+}
+
+func TestAddOrgCAMount(t *testing.T) {
+	values := map[string]any{}
+	addOrgCAMount(context.Background(), values)
+
+	repoServer, ok := values["repoServer"].(map[string]any)
+	if !ok {
+		t.Fatal("repoServer should be a map[string]any")
+	}
+
+	// Volumes: org-ca (configMap) + combined-ca (emptyDir).
+	if v := entryByName(t, repoServer["volumes"], "org-ca"); v == nil {
+		t.Fatal("org-ca volume missing")
+	} else {
+		cm, ok := v["configMap"].(map[string]any)
+		if !ok || cm["name"] != "argocd-org-ca" {
+			t.Errorf("org-ca volume should reference configMap argocd-org-ca, got %v", v["configMap"])
+		}
+	}
+	if v := entryByName(t, repoServer["volumes"], "combined-ca"); v == nil {
+		t.Fatal("combined-ca volume missing")
+	} else if _, ok := v["emptyDir"].(map[string]any); !ok {
+		t.Errorf("combined-ca volume should be an emptyDir, got %v", v)
+	}
+
+	// repo-server reads the combined bundle read-only.
+	m := entryByName(t, repoServer["volumeMounts"], "combined-ca")
+	if m == nil {
+		t.Fatal("combined-ca volumeMount missing")
+	}
+	if m["mountPath"] != "/etc/ssl/certs-combined" || m["readOnly"] != true {
+		t.Errorf("combined-ca mount = %v, want mountPath=/etc/ssl/certs-combined readOnly=true", m)
+	}
+
+	// Init container.
+	init := entryByName(t, repoServer["initContainers"], "combine-ca-bundle")
+	if init == nil {
+		t.Fatal("combine-ca-bundle initContainer missing")
+	}
+	if !strings.Contains(init["image"].(string), ".Values.repoServer.image") {
+		t.Errorf("init image should resolve from the chart's repo-server image, got %v", init["image"])
+	}
+	cmd, ok := init["command"].([]any)
+	if !ok || len(cmd) != 3 || cmd[0] != "sh" || cmd[1] != "-c" {
+		t.Fatalf("init command should be [sh -c <script>], got %v", init["command"])
+	}
+	script := cmd[2].(string)
+	for _, want := range []string{
+		"/etc/ssl/certs/ca-certificates.crt",    // system bundle source
+		"/etc/nebari/org-ca/ca.crt",             // mounted org CA
+		"/etc/ssl/certs-combined/ca-bundle.crt", // combined output
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("init script missing %q; script=%q", want, script)
+		}
+	}
+	if _, ok := init["securityContext"].(map[string]any); !ok {
+		t.Error("init container should set a securityContext")
+	}
+
+	// Env: all three vars point at the combined bundle (literal path).
+	const wantPath = "/etc/ssl/certs-combined/ca-bundle.crt"
+	env := map[string]any{}
+	for _, e := range repoServer["env"].([]map[string]any) {
+		env[e["name"].(string)] = e["value"]
+	}
+	for _, name := range []string{"SSL_CERT_FILE", "GIT_SSL_CAINFO", "CURL_CA_BUNDLE"} {
+		if env[name] != wantPath {
+			t.Errorf("env %s = %v, want %s", name, env[name], wantPath)
+		}
+	}
+}
+
+// addOrgCAMount must preserve existing repoServer keys and coexist with the
+// local-gitops mount (both append to repoServer.volumes).
+func TestAddOrgCAMountPreservesAndCoexists(t *testing.T) {
+	values := map[string]any{
+		"repoServer": map[string]any{"replicas": 2},
+	}
+	addLocalGitopsMount(context.Background(), values, "/tmp/gitops")
+	addOrgCAMount(context.Background(), values)
+
+	repoServer := values["repoServer"].(map[string]any)
+	if repoServer["replicas"] != 2 {
+		t.Errorf("existing replicas key was clobbered, got %v", repoServer["replicas"])
+	}
+	for _, name := range []string{"local-gitops", "org-ca", "combined-ca"} {
+		if entryByName(t, repoServer["volumes"], name) == nil {
+			t.Errorf("volume %q missing after both mounts applied", name)
+		}
+	}
+}
+
+func TestCreateOrUpdateConfigMap(t *testing.T) {
+	const ns = "argocd"
+	newCM := func(data string) *corev1.ConfigMap {
+		return &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "argocd-org-ca", Namespace: ns},
+			Data:       map[string]string{"ca.crt": data},
+		}
+	}
+
+	t.Run("creates when absent", func(t *testing.T) {
+		client := fake.NewSimpleClientset() //nolint:staticcheck // SA1019: NewSimpleClientset is deprecated but still functional for tests
+		if err := createOrUpdateConfigMap(context.Background(), client, newCM("CA-A")); err != nil {
+			t.Fatalf("createOrUpdateConfigMap: %v", err)
+		}
+		got, err := client.CoreV1().ConfigMaps(ns).Get(context.Background(), "argocd-org-ca", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected ConfigMap to exist: %v", err)
+		}
+		if got.Data["ca.crt"] != "CA-A" {
+			t.Errorf("data = %q, want CA-A", got.Data["ca.crt"])
+		}
+	})
+
+	t.Run("updates when data changed (rotation)", func(t *testing.T) {
+		existing := newCM("OLD-CA")
+		client := fake.NewSimpleClientset(existing) //nolint:staticcheck // SA1019: NewSimpleClientset is deprecated but still functional for tests
+		if err := createOrUpdateConfigMap(context.Background(), client, newCM("NEW-CA")); err != nil {
+			t.Fatalf("createOrUpdateConfigMap: %v", err)
+		}
+		got, _ := client.CoreV1().ConfigMaps(ns).Get(context.Background(), "argocd-org-ca", metav1.GetOptions{})
+		if got.Data["ca.crt"] != "NEW-CA" {
+			t.Errorf("rotated CA not applied: data = %q, want NEW-CA", got.Data["ca.crt"])
+		}
+	})
+
+	t.Run("no-op when data unchanged", func(t *testing.T) {
+		existing := newCM("CA-A")
+		client := fake.NewSimpleClientset(existing) //nolint:staticcheck // SA1019: NewSimpleClientset is deprecated but still functional for tests
+		if err := createOrUpdateConfigMap(context.Background(), client, newCM("CA-A")); err != nil {
+			t.Fatalf("createOrUpdateConfigMap: %v", err)
+		}
+		got, _ := client.CoreV1().ConfigMaps(ns).Get(context.Background(), "argocd-org-ca", metav1.GetOptions{})
+		if got.Data["ca.crt"] != "CA-A" {
+			t.Errorf("data = %q, want CA-A", got.Data["ca.crt"])
+		}
+	})
+}

--- a/pkg/argocd/secrets.go
+++ b/pkg/argocd/secrets.go
@@ -41,9 +41,9 @@ func ConfigureGitRepoAccess(ctx context.Context, client kubernetes.Interface, gi
 
 	// Create repository secret data
 	secretData := map[string]string{
-		"name": "gitops-repo",
-		"type": gitRepoType,
-		"url":  gitConfig.URL,
+		"name":  "gitops-repo",
+		keyType: gitRepoType,
+		"url":   gitConfig.URL,
 	}
 
 	// Try SSH key first, then token
@@ -117,7 +117,7 @@ func ConfigureOCIAccess(ctx context.Context, client kubernetes.Interface, namesp
 		Type: corev1.SecretTypeOpaque,
 		StringData: map[string]string{
 			"name":      "docker-oci",
-			"type":      "helm",
+			keyType:     "helm",
 			"url":       "oci://docker.io",
 			"enableOCI": "true",
 		},

--- a/pkg/nic/deploy.go
+++ b/pkg/nic/deploy.go
@@ -194,7 +194,7 @@ func (c *Client) Deploy(ctx context.Context, cfg *config.NebariConfig, opts Depl
 		// Build ArgoCD config with Keycloak OIDC SSO
 		argoCDConfig := argocd.ConfigWithOIDC(cfg.Domain, infraSettings.KeycloakBasePath, argoCDClientSecret)
 
-		if err := argocd.Install(ctx, cfg, clusterProvider, gitConfig, argoCDConfig); err != nil {
+		if err := argocd.Install(ctx, cfg, clusterProvider, gitConfig, trustPEM, argoCDConfig); err != nil {
 			// Log error but don't fail deployment
 			status.Send(ctx, status.NewUpdate(status.LevelWarning, "Failed to install Argo CD").
 				WithMetadata("error", err.Error()))


### PR DESCRIPTION
## Summary

Closes #310. The in-pod-trust slice of epic #307 for the ArgoCD **repo-server** — the component that clones git repos and pulls Helm/OCI charts through a TLS-inspecting egress proxy.

When a top-level `trust_bundle` is configured, this:
- creates an install-time `argocd-org-ca` ConfigMap in the `argocd` namespace from the resolved PEM, and
- bakes repo-server Helm values that mount it, run an init container combining the image's **system** CA bundle with the **org** CA into a shared `emptyDir`, and set `SSL_CERT_FILE` / `GIT_SSL_CAINFO` / `CURL_CA_BUNDLE` at the combined file (all three are needed — git ignores `SSL_CERT_FILE` alone).

Gated on `trust_bundle` being set; otherwise the repo-server is unchanged. The wiring lives behind a single `configureRepoServerCATrust` seam (no-op when unset), with the ConfigMap built by a `createOrgCAConfigMap` helper beside the other foundational create helpers — so `Install` doesn't accrete per-feature blocks.

## Why this diverges from the issue's proposed-change text

The issue suggested mounting **trust-manager's projected ConfigMap** and populating `argocd-tls-certs-cm`. Both are deliberately avoided (endorsed by the maintainer comments on #310):

1. **Install-time ConfigMap, not the projected one — bootstrap ordering.** The repo-server is what *pulls trust-manager's chart through the proxy*. trust-manager's projected `nebari-trust-bundle` ConfigMap doesn't exist until the repo-server has already synced trust-manager, which it can't do without CA trust. So the repo-server must get its CA at install time. (Keycloak — #350 — can use the projected CM because it syncs *after* trust-manager; the repo-server is upstream of it.)
2. **`argocd-tls-certs-cm` left empty on purpose.** Entries there make Argo pass `--ca-file` to git/helm, which *replaces* (not augments) the system trust pool and breaks cross-host redirects. The combined-bundle env approach is additive (system ∪ org) and is the field-proven path.

## Scope

- **repo-server only.** The application-controller's egress is the in-cluster API (validated against the service-account `ca.crt`, unaffected) and gRPC to the repo-server; it doesn't clone/fetch, so it doesn't need the org CA. If a controller-side egress case ever surfaces it can get the identical mount — noted as a follow-up, not done here.

## Notes for reviewers

- The `argocd-org-ca` ConfigMap is **upserted** (`createOrUpdateConfigMap`), not create-only like `createSecret`, so a rotated `trust_bundle` actually propagates; managed labels are reconciled on update, and a non-`NotFound` Get error is surfaced rather than masked as "absent".
- The init container runs with a hardened `securityContext` (`runAsNonRoot`, `readOnlyRootFilesystem`, drop `ALL`, `seccompProfile: RuntimeDefault`); it only writes to the shared `emptyDir`.
- The init image is the chart's own repo-server image, resolved via the chart's `tpl` pass over `repoServer.initContainers` (no hardcoded tag) — see the `helm template` caveat in the test plan.
- An `org_ca_configured` span attribute records whether trust was wired, so the skip path is observable.

## ⚠️ Known limitation — applies to fresh installs; existing clusters need a separate change

This wires the CA into the ArgoCD **Helm values**. `shouldSkipUpgrade` (added in #85) compares **chart version only**, so on a cluster where ArgoCD is already `Deployed` at the pinned version, a values-only change is **not applied** until `defaultChartVersion` is bumped. This PR intentionally does **not** touch `shouldSkipUpgrade` — making the skip logic values-aware is a cross-cutting change to the upgrade engine that affects every `nic deploy` and deserves its own issue/PR. Until that lands, this takes effect on fresh installs (or after a version bump). Tracked in #364.

## Stacking

Based on `feat/trust-manager-309` (#346), which adds the top-level `trust_bundle` config and `ResolvePEM()` this depends on. **Retarget to `main` once #346 merges.**

## Test plan

- [x] `go build`, `go vet`, `go test ./pkg/argocd/... ./pkg/nic/...` — pass.
- [x] `TestAddOrgCAMount` — injected volumes, init container (command, chart-resolved image, securityContext) and the three env vars asserted against literal paths; `TestAddOrgCAMountPreservesAndCoexists` — preserves existing `repoServer` keys and coexists with the local-gitops mount.
- [x] `TestConfigureRepoServerCATrust` — gating (empty bundle → no ConfigMap, values untouched), the foundational `part-of`/`managed-by` labels on the created ConfigMap, and that the repo-server values are wired.
- [x] `TestCreateOrUpdateConfigMap` — create / **update-on-rotation** (upsert, unlike create-only `createSecret`) / no-op-when-unchanged, the last asserting **no write action** is issued so the early-return is proven.
- [ ] **e2e (maintainer step, needs a TLS-inspected cluster):** confirm `git clone` of an HTTPS repo terminated by the proxy succeeds from the repo-server, and that `/etc/ssl/certs/ca-certificates.crt` exists in the pinned ArgoCD image. The unit tests prove the values map is built correctly; they do **not** prove the chart honors it (the `tpl`-based init image in particular) or that git trusts the file — a `helm template` render assertion is a candidate to narrow that gap.

Refs #307.
