### PR TITLE
fix(longhorn): tolerate storage-node taints for system-managed components

### DIFF
--- a/docs/adr/0002-longhorn-distributed-block-storage-for-aws.md
+++ b/docs/adr/0002-longhorn-distributed-block-storage-for-aws.md
@@ -172,32 +172,47 @@ When Longhorn is disabled (`longhorn.enabled: false`), falls back to `gp2`.
 
 Default (no longhorn section needed):
 ```yaml
-amazon_web_services:
-  region: us-west-2
-  kubernetes_version: "1.34"
-  node_groups:
-    user:
-      instance: m7i.xlarge
-      min_nodes: 0
-      max_nodes: 5
+cluster:
+  aws:
+    region: us-west-2
+    kubernetes_version: "1.34"
+    node_groups:
+      user:
+        instance: m7i.xlarge
+        min_nodes: 0
+        max_nodes: 5
 ```
 
-Explicit configuration:
+Explicit configuration with dedicated, tainted storage nodes:
 ```yaml
-amazon_web_services:
-  region: us-west-2
-  longhorn:
-    replica_count: 3
-    dedicated_nodes: true
-    node_selector:
-      node.longhorn.io/storage: "true"
+cluster:
+  aws:
+    region: us-west-2
+    node_groups:
+      storage:
+        instance: m7g.large
+        min_nodes: 2
+        max_nodes: 2
+        disk_size: 500
+        labels:
+          node.longhorn.io/storage: "true"
+        taints:
+          - key: node.longhorn.io/storage
+            value: "true"
+            effect: NO_SCHEDULE
+    longhorn:
+      replica_count: 3
+      dedicated_nodes: true
+      node_selector:
+        node.longhorn.io/storage: "true"
 ```
 
 Opt out:
 ```yaml
-amazon_web_services:
-  longhorn:
-    enabled: false
+cluster:
+  aws:
+    longhorn:
+      enabled: false
 ```
 
 ### Helm Values
@@ -218,6 +233,11 @@ Dedicated nodes deployment adds:
 ```yaml
 defaultSettings:
   createDefaultDiskLabeledNodes: true
+  # System-managed components (instance-manager, engine-image, CSI plugin) are
+  # not covered by the per-component tolerations below; they honor node taints
+  # and pinning only through these two settings.
+  taintToleration: node.longhorn.io/storage=true:NoSchedule
+  systemManagedComponentsNodeSelector: node.longhorn.io/storage:true
 
 longhornManager:
   nodeSelector:

--- a/examples/aws-config.yaml
+++ b/examples/aws-config.yaml
@@ -44,6 +44,26 @@ cluster:
         min_nodes: 1 # minimum of 1 node required
         max_nodes: 5
 
+      # Dedicated Longhorn storage nodes (production-recommended).
+      # Small instances with large gp3 disks, tainted so only Longhorn's
+      # storage components schedule here. Pair with the `longhorn` block below
+      # (dedicated_nodes: true). For one node per AZ, set min_nodes == max_nodes
+      # to the number of availability_zones above (2 here). disk_size defaults to
+      # 20 GiB, so set it explicitly; capacity comes from the disk, not the
+      # instance size.
+      storage:
+        instance: m7g.large # 2 vCPU / 8 GiB Graviton; use m7i.large for x86
+        ami_type: AL2023_ARM_64_STANDARD # omit this line for x86 instances
+        min_nodes: 2
+        max_nodes: 2
+        disk_size: 500 # GiB gp3 root volume backing /var/lib/longhorn
+        labels:
+          node.longhorn.io/storage: "true"
+        taints:
+          - key: node.longhorn.io/storage
+            value: "true"
+            effect: NO_SCHEDULE
+
       # worker:
       #   instance: m7i.xlarge
       #   min_nodes: 0
@@ -69,6 +89,17 @@ cluster:
       #   min_nodes: 0
       #   max_nodes: 2
       #   ami_type: AL2023_x86_64_NEURON
+
+    # Longhorn distributed block storage (enabled by default on AWS).
+    # Production-recommended: dedicate tainted storage nodes (see the "storage"
+    # node group above) and keep at least one replica per AZ. Note that
+    # dedicated_nodes with tainted storage nodes requires nebari-dev/nebari-infrastructure-core#356.
+    longhorn:
+      dedicated_nodes: true # pins Longhorn to nodes labeled/tainted node.longhorn.io/storage
+      replica_count: 2 # one replica per storage node / AZ; raise to 3 for 3 AZs
+      # node_selector:      # optional; defaults to {node.longhorn.io/storage: "true"}
+      #   node.longhorn.io/storage: "true"
+      # enabled: true       # default true on AWS; set false to opt out (falls back to gp2/EBS)
 
     # AWS Load Balancer Controller (LBC) configuration (optional).
     # Enabled by default. The controller authenticates via an EKS Pod Identity

--- a/examples/aws-config.yaml
+++ b/examples/aws-config.yaml
@@ -93,10 +93,10 @@ cluster:
 
     # Longhorn distributed block storage (enabled by default on AWS).
     # Production-recommended: dedicate tainted storage nodes (see the "storage"
-    # node group above) and keep at least one replica per AZ. Note:
-    # dedicated_nodes with tainted storage nodes needs the Longhorn
-    # taint-toleration fix (nebari-dev/nebari-infrastructure-core#356); present
-    # in any build that includes it.
+    # node group above) and keep at least one replica per AZ. The dedicated
+    # nodes must carry the node.longhorn.io/storage=true:NoSchedule taint shown
+    # there; NIC wires the matching tolerations for every Longhorn component
+    # (manager, driver, and the system-managed instance-manager/engine/CSI pods).
     longhorn:
       dedicated_nodes: true # pins Longhorn to nodes labeled/tainted node.longhorn.io/storage
       replica_count: 2 # one replica per storage node / AZ; raise to 3 for 3 AZs

--- a/examples/aws-config.yaml
+++ b/examples/aws-config.yaml
@@ -48,8 +48,9 @@ cluster:
       # Small instances with large gp3 disks, tainted so only Longhorn's
       # storage components schedule here. Pair with the `longhorn` block below
       # (dedicated_nodes: true). For one node per AZ, set min_nodes == max_nodes
-      # to the number of availability_zones above (2 here). disk_size defaults to
-      # 20 GiB, so set it explicitly; capacity comes from the disk, not the
+      # to the number of availability_zones above (2 here). disk_size sets the
+      # gp3 root volume size; when omitted EKS defaults it to 20 GiB, so set it
+      # explicitly for storage nodes. Capacity comes from the disk, not the
       # instance size.
       storage:
         instance: m7g.large # 2 vCPU / 8 GiB Graviton; use m7i.large for x86
@@ -92,8 +93,10 @@ cluster:
 
     # Longhorn distributed block storage (enabled by default on AWS).
     # Production-recommended: dedicate tainted storage nodes (see the "storage"
-    # node group above) and keep at least one replica per AZ. Note that
-    # dedicated_nodes with tainted storage nodes requires nebari-dev/nebari-infrastructure-core#356.
+    # node group above) and keep at least one replica per AZ. Note:
+    # dedicated_nodes with tainted storage nodes needs the Longhorn
+    # taint-toleration fix (nebari-dev/nebari-infrastructure-core#356); present
+    # in any build that includes it.
     longhorn:
       dedicated_nodes: true # pins Longhorn to nodes labeled/tainted node.longhorn.io/storage
       replica_count: 2 # one replica per storage node / AZ; raise to 3 for 3 AZs

--- a/pkg/provider/aws/provider.go
+++ b/pkg/provider/aws/provider.go
@@ -72,6 +72,24 @@ func contains(slice []string, str string) bool {
 	return false
 }
 
+// validateTaints checks that every node group taint has a key and a valid EKS
+// effect. EKS managed node group taint effects use the API enum spelling
+// (NO_SCHEDULE/NO_EXECUTE/PREFER_NO_SCHEDULE), which is what the
+// terraform-aws-eks-cluster module expects and what config taints carry; EKS
+// maps these to the Kubernetes taint effects.
+func validateTaints(nodeGroupName string, taints []Taint) error {
+	validEffects := []string{"NO_SCHEDULE", "NO_EXECUTE", "PREFER_NO_SCHEDULE"}
+	for i, taint := range taints {
+		if taint.Key == "" {
+			return fmt.Errorf("node group %s: taint %d is missing key", nodeGroupName, i)
+		}
+		if !contains(validEffects, taint.Effect) {
+			return fmt.Errorf("node group %s: taint %d has invalid effect %s (must be one of: %v)", nodeGroupName, i, taint.Effect, validEffects)
+		}
+	}
+	return nil
+}
+
 // containsSubstring checks if any string in the slice contains the substring
 func containsSubstring(slice []string, substr string) bool {
 	for _, s := range slice {
@@ -205,23 +223,9 @@ func (p *Provider) Validate(ctx context.Context, projectName string, clusterConf
 		}
 
 		// Validate taints
-		for i, taint := range nodeGroup.Taints {
-			if taint.Key == "" {
-				err := fmt.Errorf("node group %s: taint %d is missing key", nodeGroupName, i)
-				span.RecordError(err)
-				return err
-			}
-
-			// EKS managed node group taint effects use the API enum spelling
-			// (NO_SCHEDULE/NO_EXECUTE/PREFER_NO_SCHEDULE), which is what the
-			// terraform-aws-eks-cluster module expects and what config taints
-			// carry. EKS maps these to the Kubernetes taint effects.
-			validEffects := []string{"NO_SCHEDULE", "NO_EXECUTE", "PREFER_NO_SCHEDULE"}
-			if !contains(validEffects, taint.Effect) {
-				err := fmt.Errorf("node group %s: taint %d has invalid effect %s (must be one of: %v)", nodeGroupName, i, taint.Effect, validEffects)
-				span.RecordError(err)
-				return err
-			}
+		if err := validateTaints(nodeGroupName, nodeGroup.Taints); err != nil {
+			span.RecordError(err)
+			return err
 		}
 	}
 

--- a/pkg/provider/aws/provider.go
+++ b/pkg/provider/aws/provider.go
@@ -212,7 +212,11 @@ func (p *Provider) Validate(ctx context.Context, projectName string, clusterConf
 				return err
 			}
 
-			validEffects := []string{"NoSchedule", "NoExecute", "PreferNoSchedule"}
+			// EKS managed node group taint effects use the API enum spelling
+			// (NO_SCHEDULE/NO_EXECUTE/PREFER_NO_SCHEDULE), which is what the
+			// terraform-aws-eks-cluster module expects and what config taints
+			// carry. EKS maps these to the Kubernetes taint effects.
+			validEffects := []string{"NO_SCHEDULE", "NO_EXECUTE", "PREFER_NO_SCHEDULE"}
 			if !contains(validEffects, taint.Effect) {
 				err := fmt.Errorf("node group %s: taint %d has invalid effect %s (must be one of: %v)", nodeGroupName, i, taint.Effect, validEffects)
 				span.RecordError(err)

--- a/pkg/provider/aws/provider_test.go
+++ b/pkg/provider/aws/provider_test.go
@@ -96,6 +96,49 @@ func TestValidate_LoadBalancerScheme(t *testing.T) {
 	}
 }
 
+// TestValidate_TaintEffect verifies node group taint effects are validated
+// against the EKS API enum (NO_SCHEDULE/NO_EXECUTE/PREFER_NO_SCHEDULE), not the
+// Kubernetes-style spelling. A valid effect flows past the taint check to the
+// AWS credential check (so its error, if any, must not mention the effect);
+// an invalid effect is rejected at the taint check.
+func TestValidate_TaintEffect(t *testing.T) {
+	tests := []struct {
+		name          string
+		effect        string
+		wantEffectErr bool
+	}{
+		{name: "EKS NO_SCHEDULE is accepted", effect: "NO_SCHEDULE", wantEffectErr: false},
+		{name: "EKS NO_EXECUTE is accepted", effect: "NO_EXECUTE", wantEffectErr: false},
+		{name: "EKS PREFER_NO_SCHEDULE is accepted", effect: "PREFER_NO_SCHEDULE", wantEffectErr: false},
+		{name: "k8s-style NoSchedule is rejected", effect: "NoSchedule", wantEffectErr: true},
+		{name: "arbitrary string is rejected", effect: "Garbage", wantEffectErr: true},
+	}
+
+	p := NewProvider()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.ClusterConfig{Providers: map[string]any{"aws": map[string]any{
+				"region":             "us-west-2",
+				"kubernetes_version": "1.34",
+				"node_groups": map[string]any{
+					"storage": map[string]any{
+						"instance": "m7g.large",
+						"taints": []any{
+							map[string]any{"key": "node.longhorn.io/storage", "value": "true", "effect": tt.effect},
+						},
+					},
+				},
+			}}}
+
+			err := p.Validate(context.Background(), "test-project", cfg)
+			mentionsEffect := err != nil && strings.Contains(err.Error(), "invalid effect")
+			if mentionsEffect != tt.wantEffectErr {
+				t.Fatalf("effect %q: invalid-effect error = %v (err=%v), want %v", tt.effect, mentionsEffect, err, tt.wantEffectErr)
+			}
+		})
+	}
+}
+
 func TestInfraSettings_LoadBalancerScheme(t *testing.T) {
 	const schemeKey = "service.beta.kubernetes.io/aws-load-balancer-scheme"
 

--- a/pkg/provider/aws/provider_test.go
+++ b/pkg/provider/aws/provider_test.go
@@ -96,44 +96,40 @@ func TestValidate_LoadBalancerScheme(t *testing.T) {
 	}
 }
 
-// TestValidate_TaintEffect verifies node group taint effects are validated
-// against the EKS API enum (NO_SCHEDULE/NO_EXECUTE/PREFER_NO_SCHEDULE), not the
-// Kubernetes-style spelling. A valid effect flows past the taint check to the
-// AWS credential check (so its error, if any, must not mention the effect);
-// an invalid effect is rejected at the taint check.
-func TestValidate_TaintEffect(t *testing.T) {
+// TestValidateTaints verifies node group taint effects are validated against
+// the EKS API enum (NO_SCHEDULE/NO_EXECUTE/PREFER_NO_SCHEDULE), not the
+// Kubernetes-style spelling, and that a missing key is rejected. It exercises
+// the helper directly so the valid cases don't fall through Validate to the
+// AWS credential check (which would block on an IMDS timeout).
+func TestValidateTaints(t *testing.T) {
 	tests := []struct {
-		name          string
-		effect        string
-		wantEffectErr bool
+		name      string
+		taints    []Taint
+		errSubstr string // "" means no error expected
 	}{
-		{name: "EKS NO_SCHEDULE is accepted", effect: "NO_SCHEDULE", wantEffectErr: false},
-		{name: "EKS NO_EXECUTE is accepted", effect: "NO_EXECUTE", wantEffectErr: false},
-		{name: "EKS PREFER_NO_SCHEDULE is accepted", effect: "PREFER_NO_SCHEDULE", wantEffectErr: false},
-		{name: "k8s-style NoSchedule is rejected", effect: "NoSchedule", wantEffectErr: true},
-		{name: "arbitrary string is rejected", effect: "Garbage", wantEffectErr: true},
+		{name: "EKS NO_SCHEDULE is accepted", taints: []Taint{{Key: "k", Value: "v", Effect: "NO_SCHEDULE"}}},
+		{name: "EKS NO_EXECUTE is accepted", taints: []Taint{{Key: "k", Effect: "NO_EXECUTE"}}},
+		{name: "EKS PREFER_NO_SCHEDULE is accepted", taints: []Taint{{Key: "k", Effect: "PREFER_NO_SCHEDULE"}}},
+		{name: "no taints is fine", taints: nil},
+		{name: "k8s-style NoSchedule is rejected", taints: []Taint{{Key: "k", Effect: "NoSchedule"}}, errSubstr: "invalid effect"},
+		{name: "arbitrary effect is rejected", taints: []Taint{{Key: "k", Effect: "Garbage"}}, errSubstr: "invalid effect"},
+		{name: "missing key is rejected", taints: []Taint{{Effect: "NO_SCHEDULE"}}, errSubstr: "missing key"},
 	}
 
-	p := NewProvider()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := &config.ClusterConfig{Providers: map[string]any{"aws": map[string]any{
-				"region":             "us-west-2",
-				"kubernetes_version": "1.34",
-				"node_groups": map[string]any{
-					"storage": map[string]any{
-						"instance": "m7g.large",
-						"taints": []any{
-							map[string]any{"key": "node.longhorn.io/storage", "value": "true", "effect": tt.effect},
-						},
-					},
-				},
-			}}}
-
-			err := p.Validate(context.Background(), "test-project", cfg)
-			mentionsEffect := err != nil && strings.Contains(err.Error(), "invalid effect")
-			if mentionsEffect != tt.wantEffectErr {
-				t.Fatalf("effect %q: invalid-effect error = %v (err=%v), want %v", tt.effect, mentionsEffect, err, tt.wantEffectErr)
+			err := validateTaints("storage", tt.taints)
+			if tt.errSubstr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.errSubstr)
+			}
+			if !strings.Contains(err.Error(), tt.errSubstr) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tt.errSubstr)
 			}
 		})
 	}

--- a/pkg/storage/longhorn/config.go
+++ b/pkg/storage/longhorn/config.go
@@ -47,7 +47,8 @@ type Config struct {
 	// (see nodeStorageTaintToleration in install.go). So if you customize this
 	// selector, the dedicated nodes must still carry that exact taint, or the
 	// system-managed components (instance-manager, engine-image, CSI plugin)
-	// will sit Pending. Parameterizing the taint is tracked separately.
+	// will sit Pending. Parameterizing the taint is tracked in
+	// nebari-dev/nebari-infrastructure-core#363.
 	NodeSelector map[string]string `yaml:"node_selector,omitempty"`
 
 	// ClusterAutoscalerEnabled tells Longhorn whether the cluster runs the

--- a/pkg/storage/longhorn/config.go
+++ b/pkg/storage/longhorn/config.go
@@ -35,10 +35,20 @@ const (
 // is the minimal opt-in. ReplicaCount defaults to 2 — appropriate for small
 // clusters; production deploys should raise it.
 type Config struct {
-	Enabled        *bool             `yaml:"enabled,omitempty"`
-	ReplicaCount   int               `yaml:"replica_count,omitempty"`
-	DedicatedNodes bool              `yaml:"dedicated_nodes,omitempty"`
-	NodeSelector   map[string]string `yaml:"node_selector,omitempty"`
+	Enabled        *bool `yaml:"enabled,omitempty"`
+	ReplicaCount   int   `yaml:"replica_count,omitempty"`
+	DedicatedNodes bool  `yaml:"dedicated_nodes,omitempty"`
+	// NodeSelector overrides the node label Longhorn uses to place its
+	// components when DedicatedNodes is true (defaults to
+	// node.longhorn.io/storage=true). It controls only the nodeSelector side.
+	//
+	// Constraint: the taint toleration is NOT derived from this field. Longhorn
+	// always tolerates the fixed taint node.longhorn.io/storage=true:NoSchedule
+	// (see nodeStorageTaintToleration in install.go). So if you customize this
+	// selector, the dedicated nodes must still carry that exact taint, or the
+	// system-managed components (instance-manager, engine-image, CSI plugin)
+	// will sit Pending. Parameterizing the taint is tracked separately.
+	NodeSelector map[string]string `yaml:"node_selector,omitempty"`
 
 	// ClusterAutoscalerEnabled tells Longhorn whether the cluster runs the
 	// Kubernetes Cluster Autoscaler. It is not user-facing so providers set it

--- a/pkg/storage/longhorn/install.go
+++ b/pkg/storage/longhorn/install.go
@@ -229,7 +229,11 @@ func buildHelmValues(cfg *Config) map[string]any {
 		settings["createDefaultDiskLabeledNodes"] = true
 
 		nodeSelector := map[string]string{nodeStorageLabel: "true"}
-		if cfg.NodeSelector != nil {
+		// Override only when a non-empty selector is supplied. An explicitly
+		// empty map (node_selector: {}) would otherwise clear the
+		// system-managed-components node selector, silently unpinning the
+		// instance-managers from the storage nodes.
+		if len(cfg.NodeSelector) > 0 {
 			nodeSelector = cfg.NodeSelector
 		}
 
@@ -270,6 +274,10 @@ func buildHelmValues(cfg *Config) map[string]any {
 // systemManagedComponentsNodeSelector setting string ("key:value" pairs joined
 // by ";"). Keys are sorted so the generated Helm values are deterministic.
 func formatNodeSelector(sel map[string]string) string {
+	if len(sel) == 0 {
+		return ""
+	}
+
 	keys := make([]string, 0, len(sel))
 	for k := range sel {
 		keys = append(keys, k)

--- a/pkg/storage/longhorn/install.go
+++ b/pkg/storage/longhorn/install.go
@@ -3,6 +3,8 @@ package longhorn
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -21,6 +23,14 @@ const installTimeout = 10 * time.Minute
 // nodeStorageLabel is the node label Longhorn uses to identify nodes that
 // should host its storage components when DedicatedNodes is enabled.
 const nodeStorageLabel = "node.longhorn.io/storage"
+
+// nodeStorageTaintToleration is the Longhorn taint-toleration setting value
+// matching the recommended dedicated-node taint
+// (node.longhorn.io/storage=true:NoSchedule). Unlike the manager/driver
+// tolerations, this setting is what lets Longhorn's system-managed components
+// (instance-manager, engine-image, CSI plugin) schedule onto tainted nodes.
+// https://longhorn.io/docs/1.11.2/advanced-resources/deploy/taint-toleration/
+const nodeStorageTaintToleration = nodeStorageLabel + "=true:NoSchedule"
 
 // Install installs (or upgrades, if a release exists) Longhorn on the cluster
 // the kubeconfigBytes connect to.
@@ -231,6 +241,18 @@ func buildHelmValues(cfg *Config) map[string]any {
 			},
 		}
 
+		// longhornManager/longhornDriver tolerations only cover the
+		// user-deployed components. The system-managed components
+		// (instance-manager, engine-image, CSI plugin) that actually serve
+		// replicas tolerate the node taint only via the taint-toleration
+		// setting, and are confined to the storage nodes via
+		// system-managed-components-node-selector. Without both, tainting the
+		// dedicated node group prevents Longhorn from scheduling its storage
+		// engines there.
+		// https://longhorn.io/docs/1.11.2/advanced-resources/deploy/taint-toleration/
+		settings["taintToleration"] = nodeStorageTaintToleration
+		settings["systemManagedComponentsNodeSelector"] = formatNodeSelector(nodeSelector)
+
 		values["longhornManager"] = map[string]any{
 			"nodeSelector": nodeSelector,
 			"tolerations":  tolerations,
@@ -242,4 +264,21 @@ func buildHelmValues(cfg *Config) map[string]any {
 	}
 
 	return values
+}
+
+// formatNodeSelector renders a label map as Longhorn's
+// systemManagedComponentsNodeSelector setting string ("key:value" pairs joined
+// by ";"). Keys are sorted so the generated Helm values are deterministic.
+func formatNodeSelector(sel map[string]string) string {
+	keys := make([]string, 0, len(sel))
+	for k := range sel {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+":"+sel[k])
+	}
+	return strings.Join(parts, ";")
 }

--- a/pkg/storage/longhorn/iscsi.go
+++ b/pkg/storage/longhorn/iscsi.go
@@ -22,9 +22,13 @@ const iscsiDaemonSetTimeout = 3 * time.Minute
 
 // iscsiDaemonSetYAML is the Longhorn iSCSI prerequisite DaemonSet.
 // Source: https://github.com/longhorn/longhorn/blob/v1.9.2/deploy/prerequisite/longhorn-iscsi-installation.yaml
-// (removed upstream in v1.10.0; see longhorn/longhorn@600801b5 — the
-// embedded DaemonSet content still works against newer engine versions.)
-// Embedded to avoid runtime HTTP fetches and support air-gapped installs.
+// Upstream removed this manifest in v1.10.0 (longhorn/longhorn@600801b5) and the
+// pinned v1.11.2 chart no longer ships an iSCSI prerequisite under
+// deploy/prerequisite. iSCSI setup is a host-OS operation (install open-iscsi,
+// enable iscsid, load the iscsi_tcp module) that is independent of the Longhorn
+// version, so the embedded DaemonSet remains valid for v1.11.2. Embedded to
+// avoid runtime HTTP fetches and support air-gapped installs. The added
+// tolerations let it install on tainted dedicated storage nodes.
 const iscsiDaemonSetYAML = `apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/pkg/storage/longhorn/iscsi.go
+++ b/pkg/storage/longhorn/iscsi.go
@@ -43,6 +43,11 @@ spec:
     spec:
       hostNetwork: true
       hostPID: true
+      # Tolerate every taint so the iSCSI prerequisite installs on all nodes,
+      # including dedicated Longhorn storage nodes tainted to repel general
+      # workloads. This is a node-level prerequisite, not a workload.
+      tolerations:
+      - operator: Exists
       initContainers:
       - name: iscsi-installation
         command:

--- a/pkg/storage/longhorn/longhorn_test.go
+++ b/pkg/storage/longhorn/longhorn_test.go
@@ -2,6 +2,7 @@ package longhorn
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -48,14 +50,28 @@ func TestBuildHelmValues(t *testing.T) {
 				NodeSelector:   map[string]string{"node.longhorn.io/storage": "true"},
 			},
 			checkValues: map[string]any{
-				"defaultSettings.createDefaultDiskLabeledNodes": true,
+				"defaultSettings.createDefaultDiskLabeledNodes":       true,
+				"defaultSettings.taintToleration":                     "node.longhorn.io/storage=true:NoSchedule",
+				"defaultSettings.systemManagedComponentsNodeSelector": "node.longhorn.io/storage:true",
 			},
 		},
 		{
 			name:   "dedicated nodes without custom nodeSelector uses default",
 			config: &Config{DedicatedNodes: true},
 			checkValues: map[string]any{
-				"defaultSettings.createDefaultDiskLabeledNodes": true,
+				"defaultSettings.createDefaultDiskLabeledNodes":       true,
+				"defaultSettings.taintToleration":                     "node.longhorn.io/storage=true:NoSchedule",
+				"defaultSettings.systemManagedComponentsNodeSelector": "node.longhorn.io/storage:true",
+			},
+		},
+		{
+			name: "dedicated nodes with custom multi-key nodeSelector derives sorted selector setting",
+			config: &Config{
+				DedicatedNodes: true,
+				NodeSelector:   map[string]string{"workload": "storage", "tier": "longhorn"},
+			},
+			checkValues: map[string]any{
+				"defaultSettings.systemManagedComponentsNodeSelector": "tier:longhorn;workload:storage",
 			},
 		},
 		{
@@ -150,6 +166,83 @@ func TestBuildHelmValuesDedicatedNodesStructure(t *testing.T) {
 	}
 	if _, ok := driver["tolerations"].([]map[string]string); !ok {
 		t.Fatal("longhornDriver.tolerations not found or not a []map[string]string")
+	}
+}
+
+func TestBuildHelmValuesNonDedicatedOmitsSystemSettings(t *testing.T) {
+	values := buildHelmValues(&Config{DedicatedNodes: false})
+
+	settings, ok := values["defaultSettings"].(map[string]any)
+	if !ok {
+		t.Fatal("defaultSettings not found or not a map")
+	}
+	// The system-managed-component settings confine instance-managers to
+	// labeled/tainted nodes. On a colocated cluster those nodes don't exist,
+	// so the settings must not be emitted.
+	if _, ok := settings["taintToleration"]; ok {
+		t.Error("defaultSettings.taintToleration should not be set when DedicatedNodes is false")
+	}
+	if _, ok := settings["systemManagedComponentsNodeSelector"]; ok {
+		t.Error("defaultSettings.systemManagedComponentsNodeSelector should not be set when DedicatedNodes is false")
+	}
+}
+
+func TestFormatNodeSelector(t *testing.T) {
+	tests := []struct {
+		name     string
+		selector map[string]string
+		want     string
+	}{
+		{
+			name:     "single label",
+			selector: map[string]string{"node.longhorn.io/storage": "true"},
+			want:     "node.longhorn.io/storage:true",
+		},
+		{
+			name:     "multiple labels sorted by key",
+			selector: map[string]string{"workload": "storage", "tier": "longhorn"},
+			want:     "tier:longhorn;workload:storage",
+		},
+		{
+			name:     "empty selector",
+			selector: map[string]string{},
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatNodeSelector(tt.selector); got != tt.want {
+				t.Errorf("formatNodeSelector(%v) = %q, want %q", tt.selector, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestISCSIDaemonSetToleratesAllTaints(t *testing.T) {
+	var ds appsv1.DaemonSet
+	if err := yaml.NewYAMLOrJSONDecoder(
+		strings.NewReader(iscsiDaemonSetYAML), 4096,
+	).Decode(&ds); err != nil {
+		t.Fatalf("failed to parse embedded iSCSI DaemonSet YAML: %v", err)
+	}
+
+	tolerations := ds.Spec.Template.Spec.Tolerations
+	if len(tolerations) == 0 {
+		t.Fatal("iSCSI DaemonSet has no tolerations; it will skip tainted dedicated storage nodes")
+	}
+
+	// A node-level prerequisite should tolerate every taint via an unqualified
+	// Exists toleration (no key), so it installs on all nodes regardless of taint.
+	found := false
+	for _, tol := range tolerations {
+		if tol.Key == "" && tol.Operator == corev1.TolerationOpExists {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("iSCSI DaemonSet tolerations = %+v, want an Exists toleration with empty key", tolerations)
 	}
 }
 

--- a/pkg/storage/longhorn/longhorn_test.go
+++ b/pkg/storage/longhorn/longhorn_test.go
@@ -75,6 +75,16 @@ func TestBuildHelmValues(t *testing.T) {
 			},
 		},
 		{
+			name: "dedicated nodes with empty nodeSelector falls back to default label",
+			config: &Config{
+				DedicatedNodes: true,
+				NodeSelector:   map[string]string{},
+			},
+			checkValues: map[string]any{
+				"defaultSettings.systemManagedComponentsNodeSelector": "node.longhorn.io/storage:true",
+			},
+		},
+		{
 			name:   "non-dedicated nodes omits nodeSelector and tolerations",
 			config: &Config{DedicatedNodes: false, ReplicaCount: 2},
 			checkValues: map[string]any{


### PR DESCRIPTION
## What

When `dedicated_nodes: true`, NIC now sets `defaultSettings.taintToleration` and `defaultSettings.systemManagedComponentsNodeSelector` so Longhorn's system-managed components (instance-manager, engine-image, CSI plugin) can schedule onto tainted dedicated storage nodes. The embedded iSCSI prerequisite DaemonSet now tolerates all taints. The change lives in the shared `pkg/storage/longhorn` package, so every provider that installs Longhorn with dedicated nodes benefits.

Also adds a production-recommended dedicated Longhorn config (tainted storage node group, one node per AZ, small instance with a large gp3 disk, `longhorn.dedicated_nodes: true`) to `examples/aws-config.yaml`.

## Why

Previously only `longhornManager`/`longhornDriver` received the storage-node toleration. The system-managed components that serve replicas tolerate taints only via the `taint-toleration` setting, so tainting the dedicated node group left Longhorn unable to run storage engines there.

## Testing

- New table-driven tests in `pkg/storage/longhorn` for the two `defaultSettings` keys, the `formatNodeSelector` helper, and the iSCSI DaemonSet toleration.
- `go test ./...`, `go vet ./...`, `gofmt -l`, `go build ./...` all pass; `nic validate -f examples/aws-config.yaml` passes.

## Caveat

`taintToleration` is pinned to the default taint `node.longhorn.io/storage=true:NoSchedule`. Overriding `node_selector` together with a non-default taint value won't line up; that can be a follow-up if anyone needs it.

Closes #355

## Test coverage

#355 criterion 1 (Longhorn functional on tainted dedicated nodes) is covered by unit tests and `nic validate`, not an end-to-end integration test against a live cluster.
