### PR TITLE
fix(ci): run add-to-project on pull_request_target so fork PRs don't fail

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -3,7 +3,12 @@ name: Add to project
 on:
   issues:
     types: [opened, labeled, unlabeled]
-  pull_request:
+  # Use pull_request_target (not pull_request) so the ADD_TO_PROJECT_PAT secret
+  # is available on PRs opened from forks. Under pull_request, GitHub withholds
+  # secrets from cross-repo (fork) PRs, leaving the token empty and failing the
+  # job. This is safe here because the reusable workflow checks out no PR code —
+  # it only reads trusted event metadata and calls the GitHub API.
+  pull_request_target:
     types: [opened, labeled, unlabeled]
 
 jobs:


### PR DESCRIPTION
## Problem

The **`sync / sync`** check (from `.github/workflows/add-to-project.yaml`) fails on every PR opened from a **fork** — e.g. #358. The job calls the reusable `nebari-dev/.github` workflow `sync-project-priority.yaml`, passing `secrets.ADD_TO_PROJECT_PAT`:

```yaml
on:
  pull_request:
    types: [opened, labeled, unlabeled]
jobs:
  sync:
    uses: nebari-dev/.github/.github/workflows/sync-project-priority.yaml@main
    secrets:
      token: ${{ secrets.ADD_TO_PROJECT_PAT }}
```

GitHub deliberately withholds secrets from `pull_request`-triggered runs on **cross-repo (fork) PRs**. So the PAT resolves to empty, `GH_TOKEN` is blank, and the first `gh api graphql` call dies:

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
##[error]Process completed with exit code 4.
```

This is a fork-secrets limitation, not anything wrong with the contributor's PR — every external contribution hits it.

## Fix

Trigger the PR path on **`pull_request_target`** instead of `pull_request`. That event runs in the **base repo's** context, so the PAT is available even for fork PRs, and external contributions actually get added to the project board instead of erroring.

This is safe here: the reusable workflow **never checks out PR head code** — it only reads trusted event metadata (`node_id`, `labels`) and makes GitHub API calls. The usual `pull_request_target` risk (running untrusted fork code with elevated privileges) does not apply.

Issue events and same-repo PRs behave exactly as before. `pull_request_target` does not change *which* PRs trigger the workflow — only the execution context for the fork→upstream case.

## Notes

- A companion docs PR against `nebari-dev/.github` updates the reusable workflow's header comment and the README to document the `pull_request_target` requirement, so the next caller repo avoids this trap.