### PR TITLE
fix(longhorn): make dedicated_nodes serve volumes cluster-wide (#366, #369)

### DIFF
--- a/docs/adr/0002-longhorn-distributed-block-storage-for-aws.md
+++ b/docs/adr/0002-longhorn-distributed-block-storage-for-aws.md
@@ -322,3 +322,7 @@ Known limitations (tracked separately): csi-plugin tolerations come from the
 need their taint added there before mounts work on them (relates to #363/#368);
 and the disk-label injection is AWS-only — Hetzner/existing must label their
 storage pool themselves (the installer now warns when no node carries the label).
+
+Switching an existing cluster between `dedicated_nodes` modes is a manual
+replica migration (Longhorn does not move existing replicas on a flag change).
+See [Migrating Longhorn dedicated_nodes modes](../operations/longhorn-dedicated-nodes-migration.md).

--- a/docs/adr/0002-longhorn-distributed-block-storage-for-aws.md
+++ b/docs/adr/0002-longhorn-distributed-block-storage-for-aws.md
@@ -229,32 +229,34 @@ defaultSettings:
   replicaAutoBalance: best-effort
 ```
 
-Dedicated nodes deployment adds:
+Dedicated nodes deployment adds (current behavior — see "Update (2026-06)" below
+for the topology change away from component pinning):
 ```yaml
 defaultSettings:
   createDefaultDiskLabeledNodes: true
-  # System-managed components (instance-manager, engine-image, CSI plugin) are
-  # not covered by the per-component tolerations below; they honor node taints
-  # and pinning only through these two settings.
+  # Lets the replica-role system-managed components (instance-manager,
+  # engine-image, share-manager) tolerate the storage-node taint so they can run
+  # on the dedicated storage nodes. NOTE: the csi-plugin DaemonSet is also
+  # system-managed and inherits ONLY this toleration, so a tainted workload pool
+  # (e.g. GPU) would need its taint added here for mounts to work there.
   taintToleration: node.longhorn.io/storage=true:NoSchedule
-  systemManagedComponentsNodeSelector: node.longhorn.io/storage:true
 
+# longhorn-manager (DaemonSet) and the driver run on EVERY node so volumes can be
+# served to workloads anywhere — tolerate-all, NO nodeSelector. Replica DATA is
+# confined to storage nodes by createDefaultDiskLabeledNodes (only labeled
+# storage nodes get a disk), not by pinning these components.
 longhornManager:
-  nodeSelector:
-    node.longhorn.io/storage: "true"
   tolerations:
-    - key: node.longhorn.io/storage
-      operator: Exists
-      effect: NoSchedule
-
+    - operator: Exists
 longhornDriver:
-  nodeSelector:
-    node.longhorn.io/storage: "true"
   tolerations:
-    - key: node.longhorn.io/storage
-      operator: Exists
-      effect: NoSchedule
+    - operator: Exists
 ```
+
+The storage node group must carry `node.longhorn.io/create-default-disk=true`
+(the AWS provider injects it automatically; other providers must label their
+storage pool). Without it, `createDefaultDiskLabeledNodes` provisions no disks
+and every volume faults with `ReplicaSchedulingFailure`.
 
 ### Testing Strategy
 
@@ -296,3 +298,27 @@ StorageClass; `ensureISCSI` runs on the upgrade path too; chart pinned to
 
 Original AWS-only decision and tuning (replica count, anti-affinity, ext4,
 dedicated-nodes topology) unchanged.
+
+## Update (2026-06): dedicated-nodes topology (#366/#369)
+
+The original dedicated-nodes Helm values pinned the system components to the
+storage nodes (`systemManagedComponentsNodeSelector` + `nodeSelector` on
+`longhornManager`/`longhornDriver`). On a live cluster this broke PVC mounts on
+non-storage workload nodes (the csi-plugin and manager were absent there — #366),
+and the storage nodes never got disks (#369). The topology is now:
+
+- **No component pinning.** `systemManagedComponentsNodeSelector` and the
+  manager/driver `nodeSelector` are removed; manager + driver are tolerate-all so
+  they (and the csi-plugin) run on every node and can serve volumes anywhere.
+- **Replica DATA confined by disks, not pinning.** `createDefaultDiskLabeledNodes`
+  + the `node.longhorn.io/create-default-disk=true` label (provider-applied; AWS
+  injects it on storage node groups) means only storage nodes get a disk, so
+  replicas can only land there. This is autoscaler-safe (kubelet applies the label
+  at registration) and replaces the `allowScheduling`-based guard #366 originally
+  proposed.
+
+Known limitations (tracked separately): csi-plugin tolerations come from the
+`taintToleration` setting (storage taint only), so tainted workload pools (GPU)
+need their taint added there before mounts work on them (relates to #363/#368);
+and the disk-label injection is AWS-only — Hetzner/existing must label their
+storage pool themselves (the installer now warns when no node carries the label).

--- a/docs/design-doc/operations/longhorn-dedicated-nodes-migration.md
+++ b/docs/design-doc/operations/longhorn-dedicated-nodes-migration.md
@@ -1,0 +1,160 @@
+# Migrating Longhorn `dedicated_nodes` modes
+
+This document describes how to switch an existing cluster between colocated
+Longhorn (`longhorn.dedicated_nodes: false`, replicas on every node) and
+dedicated storage nodes (`dedicated_nodes: true`, replicas confined to a tainted
+storage node group), and how to upgrade a cluster from the pre-fix behavior.
+
+> **Switching modes is a manual migration, not a config toggle.** The
+> `dedicated_nodes` setting only governs *future* default-disk creation. Neither
+> NIC nor Longhorn moves or re-syncs replicas that already exist when the flag
+> changes — you migrate them yourself. See the `Config.DedicatedNodes` godoc in
+> `pkg/storage/longhorn/config.go` for the short version.
+
+## Background
+
+- `dedicated_nodes: false` renders `createDefaultDiskLabeledNodes` unset, so
+  Longhorn creates a default disk on **every** node — replicas spread across all
+  nodes.
+- `dedicated_nodes: true` renders `createDefaultDiskLabeledNodes: true`, so
+  Longhorn creates a default disk **only** on nodes labeled
+  `node.longhorn.io/create-default-disk=true` (the AWS provider injects this onto
+  the storage node group). Replicas can only land where a disk exists, so they are
+  confined to the storage nodes. The system pods (csi-plugin, manager, engine-role
+  instance-manager) are **not** pinned — they run everywhere so workloads on any
+  node can mount volumes.
+
+Changing the flag does not delete existing disks or rebuild existing replicas.
+That is why every transition below has an explicit replica-migration step.
+
+## Pre-flight (all transitions)
+
+Take a fresh **off-cluster** backup before touching topology. In-cluster
+snapshots live on the same disks you may be about to remove, so they do not
+protect you — only an S3 backup does.
+
+- Install / confirm [`nebari-longhorn-backup-pack`](https://github.com/nebari-dev/nebari-longhorn-backup-pack)
+  and a configured `BackupTarget/default` (S3 bucket + credential secret).
+- Trigger an **on-demand backup of every volume** right before the switch (the
+  scheduled job is daily — don't rely on a backup up to 24h old).
+- Restore path if anything goes wrong: Longhorn UI → Backup → restore each volume
+  onto the new topology.
+
+## Case 1: colocated → dedicated (`false` → `true`), with live data
+
+This is the careful one — you have real replicas on the general/user node disks.
+
+1. **Back up** (pre-flight above).
+2. **Add the storage node group** and deploy. The group must carry the storage
+   label, the disk-creation label, and the matching taint:
+   ```yaml
+   node_groups:
+     storage:
+       instance: m7g.large
+       ami_type: AL2023_ARM_64_STANDARD
+       min_nodes: 2
+       max_nodes: 2
+       disk_size: 500
+       labels:
+         node.longhorn.io/storage: "true"
+         node.longhorn.io/create-default-disk: "true"   # NIC also injects this
+       taints:
+         - key: node.longhorn.io/storage
+           value: "true"
+           effect: NO_SCHEDULE
+   ```
+   `nic deploy`. New storage nodes come up with Longhorn disks; existing replicas
+   stay where they are.
+3. **Flip the flag**: set `longhorn.dedicated_nodes: true`, `nic deploy`. This
+   sets `createDefaultDiskLabeledNodes: true` and un-pins the system pods. Existing
+   general/user-node disks are **not** removed, so replicas still live there — the
+   cluster is now in a hybrid state.
+4. **Migrate replicas onto the storage nodes.** For each non-storage node, request
+   eviction so Longhorn rebuilds its replicas elsewhere (only the storage nodes
+   have schedulable disks, so that's where they go):
+   ```bash
+   for n in $(kubectl get nodes -l '!node.longhorn.io/storage' -o name | sed 's|node/||'); do
+     kubectl -n longhorn-system patch nodes.longhorn.io "$n" \
+       --type=merge -p '{"spec":{"allowScheduling":false,"evictionRequested":true}}'
+   done
+   ```
+   Wait until every volume is `Healthy` with replicas only on storage nodes:
+   ```bash
+   kubectl -n longhorn-system get replicas.longhorn.io -o wide   # nodeID column all storage nodes
+   kubectl -n longhorn-system get volumes.longhorn.io -o custom-columns=NAME:.metadata.name,ROBUST:.status.robustness
+   ```
+5. The general/user nodes now hold no replicas, so they are safe to scale down and
+   their default disks can be removed (clear `evictionRequested` once drained, or
+   let the node group scale in).
+
+## Case 2: upgrading a `main` `dedicated_nodes: true` cluster to this topology
+
+On `main`, `dedicated_nodes: true` never actually worked (#369: storage nodes
+never got the disk label → zero disks → every volume faulted). So there is no
+data to preserve — this is a straight upgrade.
+
+1. `nic deploy` off the new build. The system-pod pinning is removed and the AWS
+   provider injects `node.longhorn.io/create-default-disk=true` onto the storage
+   node group.
+2. **Verify the label reached the *running* storage nodes.** An EKS managed
+   node-group label change does not reliably relabel already-running instances:
+   ```bash
+   kubectl get nodes -l node.longhorn.io/storage=true \
+     -L node.longhorn.io/create-default-disk
+   ```
+   If the `CREATE-DEFAULT-DISK` column is blank, either recycle the storage nodes
+   or apply the label directly:
+   ```bash
+   for n in $(kubectl get nodes -l node.longhorn.io/storage=true -o name | sed 's|node/||'); do
+     kubectl label node "$n" node.longhorn.io/create-default-disk=true --overwrite
+   done
+   ```
+   Disks appear within ~30s. The install-time guard (`warnIfMissingStorageDiskLabel`)
+   also emits a warning during deploy if no node carries the label.
+3. Un-pinning applies cleanly (a broken cluster has no attached volumes to block
+   the setting change).
+
+## Case 3: dedicated → colocated (`true` → `false`)
+
+**Danger:** flipping the flag *and* removing the storage node group in the same
+step tears down the nodes holding the only replicas before they are rebuilt
+elsewhere — straight data loss (the #354 node-removal hazard).
+
+1. **Back up** (pre-flight).
+2. Set `dedicated_nodes: false` but **keep the storage node group for now**,
+   `nic deploy`. `createDefaultDiskLabeledNodes` goes off, so general/user nodes
+   start getting default disks. Existing replicas stay on the storage nodes.
+3. **Migrate replicas off the storage nodes** onto the now-disk-bearing
+   general/user nodes (same eviction pattern as Case 1, step 4, but evicting the
+   *storage* nodes). Wait for every volume `Healthy` with replicas on non-storage
+   nodes.
+4. Only **after** replicas have rebuilt elsewhere, remove the storage node group
+   from the config and `nic deploy`.
+
+## Caveats
+
+- **csi-plugin on tainted workload pools (GPU).** `taintToleration` covers the
+  storage taint only, and the csi-plugin DaemonSet (system-managed) inherits its
+  tolerations from that setting — not from the tolerate-all on manager/driver. A
+  tainted GPU pool (`nvidia.com/gpu:NoSchedule`) therefore won't run csi-plugin and
+  its pods can't mount Longhorn volumes until that taint is added to
+  `taintToleration`. Tracked in #363 / #368; Refs #366.
+- **Exact-value label match.** NIC identifies the storage group by an exact
+  key/value match against `NodeSelector` (default `node.longhorn.io/storage=true`).
+  A label with any other value silently won't match and gets no disk label.
+
+## Verification (after any transition to dedicated)
+
+```bash
+# csi-plugin + manager on EVERY node (mounts work cluster-wide)
+kubectl -n longhorn-system get pods -l app=longhorn-csi-plugin -o wide
+kubectl -n longhorn-system get ds longhorn-manager -o wide
+
+# disks present and schedulable on storage nodes
+kubectl -n longhorn-system get nodes.longhorn.io <storage-node> -o jsonpath='{.status.diskStatus}'
+
+# replicas confined to storage nodes
+kubectl -n longhorn-system get replicas.longhorn.io -o wide
+
+# end-to-end: a PVC + pod on a workload (user/general) node mounts and runs
+```

--- a/examples/aws-config.yaml
+++ b/examples/aws-config.yaml
@@ -60,6 +60,10 @@ cluster:
         disk_size: 500 # GiB gp3 root volume backing /var/lib/longhorn
         labels:
           node.longhorn.io/storage: "true"
+          # Triggers Longhorn default-disk creation on these nodes. NIC injects
+          # this automatically for dedicated-nodes storage groups; shown here so
+          # the contract is explicit.
+          node.longhorn.io/create-default-disk: "true"
         taints:
           - key: node.longhorn.io/storage
             value: "true"
@@ -93,12 +97,13 @@ cluster:
 
     # Longhorn distributed block storage (enabled by default on AWS).
     # Production-recommended: dedicate tainted storage nodes (see the "storage"
-    # node group above) and keep at least one replica per AZ. The dedicated
-    # nodes must carry the node.longhorn.io/storage=true:NoSchedule taint shown
-    # there; NIC wires the matching tolerations for every Longhorn component
-    # (manager, driver, and the system-managed instance-manager/engine/CSI pods).
+    # node group above) and keep at least one replica per AZ. The dedicated nodes
+    # must carry the node.longhorn.io/storage=true:NoSchedule taint shown there;
+    # NIC tolerates it for every Longhorn component. Replicas (the data) live only
+    # on storage nodes because only they get a Longhorn disk; the csi-plugin and
+    # manager still run on every node so workloads anywhere can mount volumes.
     longhorn:
-      dedicated_nodes: true # pins Longhorn to nodes labeled/tainted node.longhorn.io/storage
+      dedicated_nodes: true # confines replica DATA to the labeled/tainted storage nodes
       replica_count: 2 # one replica per storage node / AZ; raise to 3 for 3 AZs
       # node_selector:      # optional; defaults to {node.longhorn.io/storage: "true"}
       #   node.longhorn.io/storage: "true"

--- a/pkg/provider/aws/tofu.go
+++ b/pkg/provider/aws/tofu.go
@@ -72,28 +72,22 @@ func resolveNodeGroupAMIs(nodeGroups map[string]NodeGroup) map[string]NodeGroup 
 	return result
 }
 
-// longhornStorageSelector returns the label set that identifies the dedicated
-// Longhorn storage node group: the configured NodeSelector, or the default
-// {node.longhorn.io/storage: "true"}.
-func longhornStorageSelector(cfg *longhorn.Config) map[string]string {
-	if cfg != nil && len(cfg.NodeSelector) > 0 {
-		return cfg.NodeSelector
-	}
-	return map[string]string{longhorn.NodeStorageLabel: "true"}
-}
-
-// applyLonghornDiskLabel adds longhorn.CreateDefaultDiskLabel=true to every node
-// group whose labels already match the Longhorn storage selector, so Longhorn
-// auto-provisions a disk on those nodes (#369). Node groups that aren't storage
-// nodes are left untouched.
+// applyLonghornDiskLabel ensures every node group that matches the Longhorn
+// storage selector carries the labels Longhorn needs on a storage node (the
+// selector labels plus the create-default-disk label) so Longhorn
+// auto-provisions a disk there (#369). The label policy is owned by the
+// longhorn package (StorageSelector/StorageNodeLabels); this only applies it to
+// whichever AWS node group is the storage pool. Non-storage groups are left
+// untouched.
 func applyLonghornDiskLabel(nodeGroups map[string]NodeGroup, cfg *longhorn.Config) map[string]NodeGroup {
-	sel := longhornStorageSelector(cfg)
+	sel := longhorn.StorageSelector(cfg)
+	storageLabels := longhorn.StorageNodeLabels(cfg)
 	result := make(map[string]NodeGroup, len(nodeGroups))
 	for name, group := range nodeGroups {
 		if nodeGroupMatchesSelector(group.Labels, sel) {
-			labels := make(map[string]string, len(group.Labels)+1)
+			labels := make(map[string]string, len(group.Labels)+len(storageLabels))
 			maps.Copy(labels, group.Labels)
-			labels[longhorn.CreateDefaultDiskLabel] = "true"
+			maps.Copy(labels, storageLabels)
 			group.Labels = labels
 		}
 		result[name] = group

--- a/pkg/provider/aws/tofu.go
+++ b/pkg/provider/aws/tofu.go
@@ -1,6 +1,11 @@
 package aws
 
-import "embed"
+import (
+	"embed"
+	"maps"
+
+	"github.com/nebari-dev/nebari-infrastructure-core/pkg/storage/longhorn"
+)
 
 // Embed all files in the templates directory, including dotfiles (i.e. .terraform.lock.hcl)
 //
@@ -67,7 +72,60 @@ func resolveNodeGroupAMIs(nodeGroups map[string]NodeGroup) map[string]NodeGroup 
 	return result
 }
 
+// longhornStorageSelector returns the label set that identifies the dedicated
+// Longhorn storage node group: the configured NodeSelector, or the default
+// {node.longhorn.io/storage: "true"}.
+func longhornStorageSelector(cfg *longhorn.Config) map[string]string {
+	if cfg != nil && len(cfg.NodeSelector) > 0 {
+		return cfg.NodeSelector
+	}
+	return map[string]string{longhorn.NodeStorageLabel: "true"}
+}
+
+// applyLonghornDiskLabel adds longhorn.CreateDefaultDiskLabel=true to every node
+// group whose labels already match the Longhorn storage selector, so Longhorn
+// auto-provisions a disk on those nodes (#369). Node groups that aren't storage
+// nodes are left untouched.
+func applyLonghornDiskLabel(nodeGroups map[string]NodeGroup, cfg *longhorn.Config) map[string]NodeGroup {
+	sel := longhornStorageSelector(cfg)
+	result := make(map[string]NodeGroup, len(nodeGroups))
+	for name, group := range nodeGroups {
+		if nodeGroupMatchesSelector(group.Labels, sel) {
+			labels := make(map[string]string, len(group.Labels)+1)
+			maps.Copy(labels, group.Labels)
+			labels[longhorn.CreateDefaultDiskLabel] = "true"
+			group.Labels = labels
+		}
+		result[name] = group
+	}
+	return result
+}
+
+// nodeGroupMatchesSelector reports whether labels is a superset of sel (i.e. the
+// node group carries every storage selector label). An empty selector never
+// matches, so no group is treated as storage by accident.
+func nodeGroupMatchesSelector(labels, sel map[string]string) bool {
+	if len(sel) == 0 {
+		return false
+	}
+	for k, v := range sel {
+		if labels[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
 func (c *Config) toTFVars(projectName string) (TFVars, error) {
+	nodeGroups := resolveNodeGroupAMIs(c.NodeGroups)
+	// When Longhorn runs on dedicated nodes, the storage node group(s) must carry
+	// the create-default-disk label or Longhorn provisions no disks and every
+	// volume faults (#369). Inject it here so it is applied by kubelet at node
+	// registration (autoscaler-safe) rather than via a post-install reconcile.
+	if c.LonghornEnabled() && c.Longhorn != nil && c.Longhorn.DedicatedNodes {
+		nodeGroups = applyLonghornDiskLabel(nodeGroups, c.Longhorn)
+	}
+
 	vars := TFVars{
 		Region:                 c.Region,
 		ProjectName:            projectName,
@@ -80,7 +138,7 @@ func (c *Config) toTFVars(projectName string) (TFVars, error) {
 		EndpointPublicAccess:   c.EndpointPublicAccess,
 		ClusterEnabledLogTypes: c.EnabledLogTypes,
 		CreateIAMRoles:         c.ExistingClusterRoleArn == "" && c.ExistingNodeRoleArn == "",
-		NodeGroups:             resolveNodeGroupAMIs(c.NodeGroups),
+		NodeGroups:             nodeGroups,
 		// Only provision the autoscaler's IAM role / pod identity association
 		// when the autoscaler itself will be installed (see provider deploy).
 		EnableClusterAutoscalerPodIdentity: c.ClusterAutoscalerEnabled(),

--- a/pkg/provider/aws/tofu_test.go
+++ b/pkg/provider/aws/tofu_test.go
@@ -361,4 +361,44 @@ func TestToTFVarsLonghornDiskLabel(t *testing.T) {
 			t.Error("group not matching the custom selector must not get the disk label")
 		}
 	})
+
+	t.Run("labels multiple storage groups, idempotent, literal wire value", func(t *testing.T) {
+		cfg := Config{
+			Region:            "us-west-2",
+			KubernetesVersion: "1.34",
+			Longhorn:          &longhorn.Config{DedicatedNodes: true},
+			NodeGroups: map[string]NodeGroup{
+				"storage-a": {Instance: "m7g.large", Labels: map[string]string{longhorn.NodeStorageLabel: "true"}},
+				// already carries the disk label — injection must be idempotent
+				"storage-b": {Instance: "m7g.large", Labels: map[string]string{
+					longhorn.NodeStorageLabel:              "true",
+					"node.longhorn.io/create-default-disk": "true",
+				}},
+			},
+		}
+		vars, err := cfg.toTFVars("test")
+		if err != nil {
+			t.Fatalf("toTFVars: %v", err)
+		}
+		// literal wire value, both groups
+		for _, g := range []string{"storage-a", "storage-b"} {
+			if vars.NodeGroups[g].Labels["node.longhorn.io/create-default-disk"] != "true" {
+				t.Errorf("%s missing create-default-disk=true, got %v", g, vars.NodeGroups[g].Labels)
+			}
+		}
+	})
+
+	t.Run("does not mutate the caller's node-group labels", func(t *testing.T) {
+		cfg := newCfg(true, nil)
+		if _, ok := cfg.NodeGroups["storage"].Labels[diskLabel]; ok {
+			t.Fatal("precondition: input already has the disk label")
+		}
+		if _, err := cfg.toTFVars("test"); err != nil {
+			t.Fatalf("toTFVars: %v", err)
+		}
+		// the original config's label map must be untouched (no aliasing)
+		if _, ok := cfg.NodeGroups["storage"].Labels[diskLabel]; ok {
+			t.Error("toTFVars mutated the caller's NodeGroup.Labels map")
+		}
+	})
 }

--- a/pkg/provider/aws/tofu_test.go
+++ b/pkg/provider/aws/tofu_test.go
@@ -299,3 +299,66 @@ func TestToTFVarsEnableIRSA(t *testing.T) {
 		}
 	})
 }
+
+func TestToTFVarsLonghornDiskLabel(t *testing.T) {
+	const diskLabel = longhorn.CreateDefaultDiskLabel
+
+	newCfg := func(dedicated bool, selector map[string]string) Config {
+		return Config{
+			Region:            "us-west-2",
+			KubernetesVersion: "1.34",
+			Longhorn:          &longhorn.Config{DedicatedNodes: dedicated, NodeSelector: selector},
+			NodeGroups: map[string]NodeGroup{
+				"storage": {Instance: "m7g.large", Labels: map[string]string{longhorn.NodeStorageLabel: "true"}},
+				"user":    {Instance: "m7i.xlarge"},
+			},
+		}
+	}
+
+	t.Run("dedicated nodes injects disk label onto storage group only", func(t *testing.T) {
+		cfg := newCfg(true, nil)
+		vars, err := cfg.toTFVars("test")
+		if err != nil {
+			t.Fatalf("toTFVars: %v", err)
+		}
+		if got := vars.NodeGroups["storage"].Labels[diskLabel]; got != "true" {
+			t.Errorf("storage group %s = %q, want %q", diskLabel, got, "true")
+		}
+		if _, ok := vars.NodeGroups["user"].Labels[diskLabel]; ok {
+			t.Errorf("user group must not get %s", diskLabel)
+		}
+	})
+
+	t.Run("disk label not injected when dedicated_nodes is false", func(t *testing.T) {
+		cfg := newCfg(false, nil)
+		vars, err := cfg.toTFVars("test")
+		if err != nil {
+			t.Fatalf("toTFVars: %v", err)
+		}
+		if _, ok := vars.NodeGroups["storage"].Labels[diskLabel]; ok {
+			t.Errorf("no group should get %s when dedicated_nodes is false", diskLabel)
+		}
+	})
+
+	t.Run("custom NodeSelector identifies the storage group", func(t *testing.T) {
+		cfg := Config{
+			Region:            "us-west-2",
+			KubernetesVersion: "1.34",
+			Longhorn:          &longhorn.Config{DedicatedNodes: true, NodeSelector: map[string]string{"pool": "lh"}},
+			NodeGroups: map[string]NodeGroup{
+				"storage": {Instance: "m7g.large", Labels: map[string]string{"pool": "lh"}},
+				"user":    {Instance: "m7i.xlarge", Labels: map[string]string{longhorn.NodeStorageLabel: "true"}},
+			},
+		}
+		vars, err := cfg.toTFVars("test")
+		if err != nil {
+			t.Fatalf("toTFVars: %v", err)
+		}
+		if got := vars.NodeGroups["storage"].Labels[diskLabel]; got != "true" {
+			t.Errorf("custom-selector storage group %s = %q, want %q", diskLabel, got, "true")
+		}
+		if _, ok := vars.NodeGroups["user"].Labels[diskLabel]; ok {
+			t.Error("group not matching the custom selector must not get the disk label")
+		}
+	})
+}

--- a/pkg/storage/longhorn/config.go
+++ b/pkg/storage/longhorn/config.go
@@ -15,6 +15,20 @@ const (
 	// ReleaseName is the Helm release name used for Longhorn.
 	ReleaseName = "longhorn"
 
+	// NodeStorageLabel marks a node as a dedicated Longhorn storage node. It is
+	// the default Config.NodeSelector and the label providers put on their
+	// storage node group.
+	NodeStorageLabel = "node.longhorn.io/storage"
+
+	// CreateDefaultDiskLabel is the label Longhorn requires on a node before it
+	// auto-provisions a default disk at /var/lib/longhorn (paired with the
+	// createDefaultDiskLabeledNodes setting this package enables for dedicated
+	// nodes). CONTRACT: when DedicatedNodes is true, every storage node group
+	// MUST carry this label, or Longhorn creates no disks and all volumes fault
+	// with ReplicaSchedulingFailure (#369). The AWS provider injects it
+	// automatically; other providers must add it to their storage pool.
+	CreateDefaultDiskLabel = "node.longhorn.io/create-default-disk"
+
 	// ChartVersion pins the upstream Longhorn Helm chart version. Bump
 	// together with iscsiDaemonSetYAML when upgrading.
 	// v1.11.2 (released 2026-05-05) includes the (*Controller).Snapshot
@@ -38,16 +52,20 @@ type Config struct {
 	Enabled        *bool `yaml:"enabled,omitempty"`
 	ReplicaCount   int   `yaml:"replica_count,omitempty"`
 	DedicatedNodes bool  `yaml:"dedicated_nodes,omitempty"`
-	// NodeSelector overrides the node label Longhorn uses to place its
-	// components when DedicatedNodes is true (defaults to
-	// node.longhorn.io/storage=true). It controls only the nodeSelector side.
+	// NodeSelector is the label set that identifies the dedicated storage nodes
+	// when DedicatedNodes is true (defaults to {node.longhorn.io/storage: "true"},
+	// i.e. NodeStorageLabel). It no longer pins Longhorn's system components by
+	// node selector — pinning broke PVC mounts on workload nodes (#366). Instead
+	// it tells the provider which node group is the storage pool, so the provider
+	// can add CreateDefaultDiskLabel to it; Longhorn then provisions disks only
+	// there, which is what confines replicas to storage nodes.
 	//
-	// Constraint: the taint toleration is NOT derived from this field. Longhorn
-	// always tolerates the fixed taint node.longhorn.io/storage=true:NoSchedule
-	// (see nodeStorageTaintToleration in install.go). So if you customize this
-	// selector, the dedicated nodes must still carry that exact taint, or the
-	// system-managed components (instance-manager, engine-image, CSI plugin)
-	// will sit Pending. Parameterizing the taint is tracked in
+	// Constraint: the taint toleration is NOT derived from this field. Longhorn's
+	// system components always tolerate the fixed taint
+	// node.longhorn.io/storage=true:NoSchedule (see nodeStorageTaintToleration in
+	// install.go). If you customize this selector, the storage nodes must still
+	// carry that exact taint, or the replica-role components can't run there.
+	// Parameterizing the taint is tracked in
 	// nebari-dev/nebari-infrastructure-core#363.
 	NodeSelector map[string]string `yaml:"node_selector,omitempty"`
 

--- a/pkg/storage/longhorn/config.go
+++ b/pkg/storage/longhorn/config.go
@@ -49,9 +49,29 @@ const (
 // is the minimal opt-in. ReplicaCount defaults to 2 — appropriate for small
 // clusters; production deploys should raise it.
 type Config struct {
-	Enabled        *bool `yaml:"enabled,omitempty"`
-	ReplicaCount   int   `yaml:"replica_count,omitempty"`
-	DedicatedNodes bool  `yaml:"dedicated_nodes,omitempty"`
+	Enabled      *bool `yaml:"enabled,omitempty"`
+	ReplicaCount int   `yaml:"replica_count,omitempty"`
+
+	// DedicatedNodes confines Longhorn replica data to a dedicated, tainted
+	// storage node group (disks are created only there; see NodeSelector and
+	// CreateDefaultDiskLabel).
+	//
+	// WARNING — toggling this is a MANUAL migration, not a hands-off switch.
+	// The setting only governs FUTURE default-disk creation; it never moves or
+	// re-syncs replicas that already exist, and neither NIC nor Longhorn migrates
+	// them for you:
+	//   - false -> true: existing replicas stay on the colocated (general/user)
+	//     node disks — Longhorn does not delete those disks on a setting change.
+	//     Those nodes then cannot scale down (they still hold replicas) and the
+	//     data is NOT auto-moved to the storage nodes. To finish the migration,
+	//     manually evict the old disks/nodes in Longhorn (allowScheduling:false
+	//     or evictionRequested) so replicas rebuild onto the storage nodes first.
+	//   - true -> false while also removing the storage node group: terraform
+	//     tears down the nodes holding the only replicas before they are rebuilt
+	//     elsewhere -> DATA LOSS (this is the #354 node-removal hazard). Migrate
+	//     replicas off the storage nodes (evict, wait for rebuild) BEFORE removing
+	//     the group.
+	DedicatedNodes bool `yaml:"dedicated_nodes,omitempty"`
 	// NodeSelector is the label set that identifies the dedicated storage nodes
 	// when DedicatedNodes is true (defaults to {node.longhorn.io/storage: "true"},
 	// i.e. NodeStorageLabel). It no longer pins Longhorn's system components by

--- a/pkg/storage/longhorn/config.go
+++ b/pkg/storage/longhorn/config.go
@@ -71,6 +71,12 @@ type Config struct {
 	//     elsewhere -> DATA LOSS (this is the #354 node-removal hazard). Migrate
 	//     replicas off the storage nodes (evict, wait for rebuild) BEFORE removing
 	//     the group.
+	//
+	// Before switching modes, take a fresh OFF-CLUSTER backup (the
+	// nebari-longhorn-backup-pack provides scheduled S3 backups; trigger an
+	// on-demand one right before the switch). In-cluster snapshots do not survive
+	// the destructive true->false case since they live on the disks being removed;
+	// only the S3 backup does, and you can restore onto the new topology.
 	DedicatedNodes bool `yaml:"dedicated_nodes,omitempty"`
 	// NodeSelector is the label set that identifies the dedicated storage nodes
 	// when DedicatedNodes is true (defaults to {node.longhorn.io/storage: "true"},

--- a/pkg/storage/longhorn/config.go
+++ b/pkg/storage/longhorn/config.go
@@ -60,6 +60,11 @@ type Config struct {
 	// can add CreateDefaultDiskLabel to it; Longhorn then provisions disks only
 	// there, which is what confines replicas to storage nodes.
 	//
+	// Matching is an exact key/value comparison: a storage node group labeled
+	// node.longhorn.io/storage="yes" (any value other than the configured one)
+	// will not match, so it gets no disk label and its volumes fault. Use the
+	// exact values set here.
+	//
 	// Constraint: the taint toleration is NOT derived from this field. Longhorn's
 	// system components always tolerate the fixed taint
 	// node.longhorn.io/storage=true:NoSchedule (see nodeStorageTaintToleration in

--- a/pkg/storage/longhorn/config.go
+++ b/pkg/storage/longhorn/config.go
@@ -92,12 +92,10 @@ type Config struct {
 	// exact values set here.
 	//
 	// Constraint: the taint toleration is NOT derived from this field. Longhorn's
-	// system components always tolerate the fixed taint
-	// node.longhorn.io/storage=true:NoSchedule (see nodeStorageTaintToleration in
-	// install.go). If you customize this selector, the storage nodes must still
-	// carry that exact taint, or the replica-role components can't run there.
-	// Parameterizing the taint is tracked in
-	// nebari-dev/nebari-infrastructure-core#363.
+	// system components tolerate every taint (see tolerateAllTaints in install.go),
+	// so the storage nodes' taint - and any taint on a workload pool where a PVC
+	// must mount - is covered regardless of what you set here. This selector only
+	// controls which nodes are labeled as the storage (replica) pool.
 	NodeSelector map[string]string `yaml:"node_selector,omitempty"`
 
 	// ClusterAutoscalerEnabled tells Longhorn whether the cluster runs the

--- a/pkg/storage/longhorn/install.go
+++ b/pkg/storage/longhorn/install.go
@@ -130,6 +130,11 @@ func Install(ctx context.Context, kubeconfigBytes []byte, cfg *Config) error {
 		return fmt.Errorf("failed to demote previous default StorageClass: %w", err)
 	}
 
+	if err := warnIfMissingStorageDiskLabel(ctx, kubeconfigBytes, cfg); err != nil {
+		span.RecordError(err)
+		return fmt.Errorf("failed to verify storage-node disk label: %w", err)
+	}
+
 	status.Send(ctx, status.NewUpdate(status.LevelSuccess, "Longhorn storage installed").
 		WithResource("longhorn").
 		WithAction("installed").
@@ -171,6 +176,11 @@ func upgrade(ctx context.Context, actionConfig *action.Configuration, kubeconfig
 	if err := ensureSoleDefaultStorageClass(ctx, kubeconfigBytes, StorageClassName); err != nil {
 		span.RecordError(err)
 		return fmt.Errorf("failed to demote previous default StorageClass: %w", err)
+	}
+
+	if err := warnIfMissingStorageDiskLabel(ctx, kubeconfigBytes, cfg); err != nil {
+		span.RecordError(err)
+		return fmt.Errorf("failed to verify storage-node disk label: %w", err)
 	}
 
 	status.Send(ctx, status.NewUpdate(status.LevelSuccess, "Longhorn storage upgraded").
@@ -236,11 +246,17 @@ func buildHelmValues(cfg *Config) map[string]any {
 		// the dedicated storage nodes that host replicas.
 		settings["taintToleration"] = nodeStorageTaintToleration
 
-		// longhorn-manager (DaemonSet) and the driver deployer must run on EVERY
-		// node so a volume can be served to a workload anywhere — they are
-		// node-level infrastructure, not workloads, so they tolerate all taints
-		// (same rationale as the embedded iSCSI prerequisite DaemonSet). They are
-		// deliberately NOT given a nodeSelector (#366).
+		// longhorn-manager (DaemonSet) and the driver deployer are node-level
+		// infrastructure, not workloads, so they tolerate all taints (same
+		// rationale as the embedded iSCSI prerequisite DaemonSet) and carry no
+		// nodeSelector (#366). NOTE: the per-node *mount* component,
+		// longhorn-csi-plugin, is system-managed — its tolerations come from the
+		// taintToleration setting above (storage taint only), NOT from these
+		// manager/driver tolerations. So mounts work on untainted workload nodes
+		// and on the storage nodes, but a *tainted* workload pool (e.g. a GPU pool
+		// with nvidia.com/gpu:NoSchedule) would need its taint added to
+		// taintToleration for csi-plugin to land there. Tracked as a follow-up
+		// (relates to #363/#368).
 		tolerateAll := []map[string]any{{"operator": "Exists"}}
 		values["longhornManager"] = map[string]any{"tolerations": tolerateAll}
 		values["longhornDriver"] = map[string]any{"tolerations": tolerateAll}

--- a/pkg/storage/longhorn/install.go
+++ b/pkg/storage/longhorn/install.go
@@ -3,8 +3,6 @@ package longhorn
 import (
 	"context"
 	"fmt"
-	"sort"
-	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -20,17 +18,14 @@ import (
 
 const installTimeout = 10 * time.Minute
 
-// nodeStorageLabel is the node label Longhorn uses to identify nodes that
-// should host its storage components when DedicatedNodes is enabled.
-const nodeStorageLabel = "node.longhorn.io/storage"
-
 // nodeStorageTaintToleration is the Longhorn taint-toleration setting value
 // matching the recommended dedicated-node taint
-// (node.longhorn.io/storage=true:NoSchedule). Unlike the manager/driver
-// tolerations, this setting is what lets Longhorn's system-managed components
-// (instance-manager, engine-image, CSI plugin) schedule onto tainted nodes.
+// (node.longhorn.io/storage=true:NoSchedule). This setting is what lets
+// Longhorn's system-managed components (instance-manager, engine-image,
+// CSI plugin) tolerate the storage-node taint so the replica-serving
+// components can run on the dedicated storage nodes.
 // https://longhorn.io/docs/1.11.2/advanced-resources/deploy/taint-toleration/
-const nodeStorageTaintToleration = nodeStorageLabel + "=true:NoSchedule"
+const nodeStorageTaintToleration = NodeStorageLabel + "=true:NoSchedule"
 
 // Install installs (or upgrades, if a release exists) Longhorn on the cluster
 // the kubeconfigBytes connect to.
@@ -226,78 +221,30 @@ func buildHelmValues(cfg *Config) map[string]any {
 	}
 
 	if cfg != nil && cfg.DedicatedNodes {
+		// Storage nodes auto-provision a Longhorn disk: createDefaultDiskLabeledNodes
+		// makes Longhorn create a default disk only on nodes carrying the
+		// CreateDefaultDiskLabel (the AWS provider adds it to storage node groups;
+		// other providers must label their storage pool — see config.go). Because
+		// only storage nodes get a disk, replicas can only ever land on storage
+		// nodes. We therefore do NOT pin the system components by node selector:
+		// doing so kept longhorn-csi-plugin and longhorn-manager off workload
+		// nodes and broke PVC mounts there (#366).
 		settings["createDefaultDiskLabeledNodes"] = true
 
-		nodeSelector := map[string]string{nodeStorageLabel: "true"}
-		// Override only when a non-empty selector is supplied. An explicitly
-		// empty map (node_selector: {}) would otherwise clear the
-		// system-managed-components node selector, silently unpinning the
-		// instance-managers from the storage nodes.
-		if len(cfg.NodeSelector) > 0 {
-			nodeSelector = cfg.NodeSelector
-		}
-
-		tolerations := []map[string]string{
-			{
-				"key":      nodeStorageLabel,
-				"operator": "Exists",
-				"effect":   "NoSchedule",
-			},
-		}
-
-		// longhornManager/longhornDriver tolerations only cover the
-		// user-deployed components. The system-managed components
-		// (instance-manager, engine-image, CSI plugin) that actually serve
-		// replicas tolerate the node taint only via the taint-toleration
-		// setting, and are confined to the storage nodes via
-		// system-managed-components-node-selector. Without both, tainting the
-		// dedicated node group prevents Longhorn from scheduling its storage
-		// engines there.
-		// https://longhorn.io/docs/1.11.2/advanced-resources/deploy/taint-toleration/
+		// System-managed components (replica-role instance-managers, engine-image,
+		// share-manager) must tolerate the storage-node taint so they can run on
+		// the dedicated storage nodes that host replicas.
 		settings["taintToleration"] = nodeStorageTaintToleration
-		settings["systemManagedComponentsNodeSelector"] = formatNodeSelector(nodeSelector)
 
-		// Helm's value coalescing only treats map[string]any as a "table"
-		// (chartutil.istable). A map[string]string nested in the values is seen
-		// as a non-table, so coalescing it against the chart's nodeSelector: {}
-		// default emits "cannot overwrite table with non table" and skips the
-		// merge. Convert to map[string]any so longhornManager/longhornDriver
-		// actually receive the selector.
-		nodeSelectorValue := make(map[string]any, len(nodeSelector))
-		for k, v := range nodeSelector {
-			nodeSelectorValue[k] = v
-		}
-
-		values["longhornManager"] = map[string]any{
-			"nodeSelector": nodeSelectorValue,
-			"tolerations":  tolerations,
-		}
-		values["longhornDriver"] = map[string]any{
-			"nodeSelector": nodeSelectorValue,
-			"tolerations":  tolerations,
-		}
+		// longhorn-manager (DaemonSet) and the driver deployer must run on EVERY
+		// node so a volume can be served to a workload anywhere — they are
+		// node-level infrastructure, not workloads, so they tolerate all taints
+		// (same rationale as the embedded iSCSI prerequisite DaemonSet). They are
+		// deliberately NOT given a nodeSelector (#366).
+		tolerateAll := []map[string]any{{"operator": "Exists"}}
+		values["longhornManager"] = map[string]any{"tolerations": tolerateAll}
+		values["longhornDriver"] = map[string]any{"tolerations": tolerateAll}
 	}
 
 	return values
-}
-
-// formatNodeSelector renders a label map as Longhorn's
-// systemManagedComponentsNodeSelector setting string ("key:value" pairs joined
-// by ";"). Keys are sorted so the generated Helm values are deterministic.
-func formatNodeSelector(sel map[string]string) string {
-	if len(sel) == 0 {
-		return ""
-	}
-
-	keys := make([]string, 0, len(sel))
-	for k := range sel {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	parts := make([]string, 0, len(keys))
-	for _, k := range keys {
-		parts = append(parts, k+":"+sel[k])
-	}
-	return strings.Join(parts, ";")
 }

--- a/pkg/storage/longhorn/install.go
+++ b/pkg/storage/longhorn/install.go
@@ -257,12 +257,23 @@ func buildHelmValues(cfg *Config) map[string]any {
 		settings["taintToleration"] = nodeStorageTaintToleration
 		settings["systemManagedComponentsNodeSelector"] = formatNodeSelector(nodeSelector)
 
+		// Helm's value coalescing only treats map[string]any as a "table"
+		// (chartutil.istable). A map[string]string nested in the values is seen
+		// as a non-table, so coalescing it against the chart's nodeSelector: {}
+		// default emits "cannot overwrite table with non table" and skips the
+		// merge. Convert to map[string]any so longhornManager/longhornDriver
+		// actually receive the selector.
+		nodeSelectorValue := make(map[string]any, len(nodeSelector))
+		for k, v := range nodeSelector {
+			nodeSelectorValue[k] = v
+		}
+
 		values["longhornManager"] = map[string]any{
-			"nodeSelector": nodeSelector,
+			"nodeSelector": nodeSelectorValue,
 			"tolerations":  tolerations,
 		}
 		values["longhornDriver"] = map[string]any{
-			"nodeSelector": nodeSelector,
+			"nodeSelector": nodeSelectorValue,
 			"tolerations":  tolerations,
 		}
 	}

--- a/pkg/storage/longhorn/install.go
+++ b/pkg/storage/longhorn/install.go
@@ -18,14 +18,19 @@ import (
 
 const installTimeout = 10 * time.Minute
 
-// nodeStorageTaintToleration is the Longhorn taint-toleration setting value
-// matching the recommended dedicated-node taint
-// (node.longhorn.io/storage=true:NoSchedule). This setting is what lets
-// Longhorn's system-managed components (instance-manager, engine-image,
-// CSI plugin) tolerate the storage-node taint so the replica-serving
-// components can run on the dedicated storage nodes.
+// tolerateAllTaints is the Longhorn taint-toleration setting value that tells
+// Longhorn's system-managed components (longhorn-csi-plugin, the replica/engine
+// instance-managers, engine-image, share-manager) to tolerate EVERY taint.
+// Longhorn parses the bare ":" as a toleration with an empty key and
+// Operator=Exists, which matches all taints regardless of key, value, or effect.
+// The csi-plugin is the per-node mount driver, so it must run on every node a
+// workload pod might land on - including tainted pools (the storage taint, a GPU
+// pool's nvidia.com/gpu:NoSchedule, any config-driven taint) - or PVC mounts
+// fail there (#366). Replica DATA is still confined to storage nodes because
+// only they carry CreateDefaultDiskLabel and thus get a Longhorn disk (#369).
+// https://github.com/longhorn/longhorn-manager/blob/v1.11.2/types/setting.go
 // https://longhorn.io/docs/1.11.2/advanced-resources/deploy/taint-toleration/
-const nodeStorageTaintToleration = NodeStorageLabel + "=true:NoSchedule"
+const tolerateAllTaints = ":"
 
 // Install installs (or upgrades, if a release exists) Longhorn on the cluster
 // the kubeconfigBytes connect to.
@@ -241,22 +246,19 @@ func buildHelmValues(cfg *Config) map[string]any {
 		// nodes and broke PVC mounts there (#366).
 		settings["createDefaultDiskLabeledNodes"] = true
 
-		// System-managed components (replica-role instance-managers, engine-image,
-		// share-manager) must tolerate the storage-node taint so they can run on
-		// the dedicated storage nodes that host replicas.
-		settings["taintToleration"] = nodeStorageTaintToleration
+		// System-managed components - crucially the per-node longhorn-csi-plugin,
+		// plus the replica/engine instance-managers, engine-image and share-manager
+		// - tolerate EVERY taint via the tolerate-all taintToleration. The csi-plugin
+		// must run wherever a workload pod can be scheduled, including tainted pools
+		// (storage taint, a GPU pool's nvidia.com/gpu:NoSchedule, any config-driven
+		// taint), or PVC mounts fail there (#366). Replica DATA stays on storage
+		// nodes regardless, because only they get a Longhorn disk (#369).
+		settings["taintToleration"] = tolerateAllTaints
 
 		// longhorn-manager (DaemonSet) and the driver deployer are node-level
-		// infrastructure, not workloads, so they tolerate all taints (same
+		// infrastructure, not workloads, so they also tolerate all taints (same
 		// rationale as the embedded iSCSI prerequisite DaemonSet) and carry no
-		// nodeSelector (#366). NOTE: the per-node *mount* component,
-		// longhorn-csi-plugin, is system-managed — its tolerations come from the
-		// taintToleration setting above (storage taint only), NOT from these
-		// manager/driver tolerations. So mounts work on untainted workload nodes
-		// and on the storage nodes, but a *tainted* workload pool (e.g. a GPU pool
-		// with nvidia.com/gpu:NoSchedule) would need its taint added to
-		// taintToleration for csi-plugin to land there. Tracked as a follow-up
-		// (relates to #363/#368).
+		// nodeSelector (#366).
 		tolerateAll := []map[string]any{{"operator": "Exists"}}
 		values["longhornManager"] = map[string]any{"tolerations": tolerateAll}
 		values["longhornDriver"] = map[string]any{"tolerations": tolerateAll}

--- a/pkg/storage/longhorn/longhorn_test.go
+++ b/pkg/storage/longhorn/longhorn_test.go
@@ -45,11 +45,11 @@ func TestBuildHelmValues(t *testing.T) {
 			},
 		},
 		{
-			name:   "dedicated nodes set disk + taint-toleration settings, not a node selector",
+			name:   "dedicated nodes set disk + tolerate-all taint setting, not a node selector",
 			config: &Config{DedicatedNodes: true},
 			checkValues: map[string]any{
 				"defaultSettings.createDefaultDiskLabeledNodes": true,
-				"defaultSettings.taintToleration":               "node.longhorn.io/storage=true:NoSchedule",
+				"defaultSettings.taintToleration":               ":",
 			},
 			// system components must NOT be pinned by node selector (#366);
 			// confinement comes from disks only existing on storage nodes.
@@ -123,8 +123,8 @@ func TestBuildHelmValuesDedicatedNodesStructure(t *testing.T) {
 	if settings["createDefaultDiskLabeledNodes"] != true {
 		t.Errorf("defaultSettings.createDefaultDiskLabeledNodes = %v, want true", settings["createDefaultDiskLabeledNodes"])
 	}
-	if settings["taintToleration"] != "node.longhorn.io/storage=true:NoSchedule" {
-		t.Errorf("defaultSettings.taintToleration = %v, want the storage taint", settings["taintToleration"])
+	if settings["taintToleration"] != ":" {
+		t.Errorf("defaultSettings.taintToleration = %v, want \":\" (tolerate all taints)", settings["taintToleration"])
 	}
 	if _, ok := settings["systemManagedComponentsNodeSelector"]; ok {
 		t.Error("defaultSettings.systemManagedComponentsNodeSelector must not be set (pinning removed, #366)")

--- a/pkg/storage/longhorn/longhorn_test.go
+++ b/pkg/storage/longhorn/longhorn_test.go
@@ -142,9 +142,14 @@ func TestBuildHelmValuesDedicatedNodesStructure(t *testing.T) {
 	if !ok {
 		t.Fatal("longhornManager not found or not a map")
 	}
-	ns, ok := manager["nodeSelector"].(map[string]string)
+	// nodeSelector must be map[string]any, not map[string]string: Helm's value
+	// coalescing only treats map[string]any as a table (chartutil.istable), so
+	// a map[string]string nested here trips "cannot overwrite table with non
+	// table" against the chart's nodeSelector: {} default and the selector is
+	// dropped, leaving longhornManager/longhornDriver unpinned. See #365.
+	ns, ok := manager["nodeSelector"].(map[string]any)
 	if !ok {
-		t.Fatal("longhornManager.nodeSelector not found or not a map[string]string")
+		t.Fatal("longhornManager.nodeSelector not found or not a map[string]any")
 	}
 	if ns["node.longhorn.io/storage"] != "true" {
 		t.Errorf("longhornManager.nodeSelector[node.longhorn.io/storage] = %q, want %q", ns["node.longhorn.io/storage"], "true")
@@ -171,8 +176,8 @@ func TestBuildHelmValuesDedicatedNodesStructure(t *testing.T) {
 	if !ok {
 		t.Fatal("longhornDriver not found or not a map")
 	}
-	if _, ok := driver["nodeSelector"].(map[string]string); !ok {
-		t.Fatal("longhornDriver.nodeSelector not found or not a map[string]string")
+	if _, ok := driver["nodeSelector"].(map[string]any); !ok {
+		t.Fatal("longhornDriver.nodeSelector not found or not a map[string]any")
 	}
 	if _, ok := driver["tolerations"].([]map[string]string); !ok {
 		t.Fatal("longhornDriver.tolerations not found or not a []map[string]string")

--- a/pkg/storage/longhorn/longhorn_test.go
+++ b/pkg/storage/longhorn/longhorn_test.go
@@ -114,6 +114,22 @@ func TestBuildHelmValuesDedicatedNodesStructure(t *testing.T) {
 
 	values := buildHelmValues(cfg)
 
+	// Full dedicated-nodes contract on defaultSettings: disk auto-creation +
+	// taint-toleration present, and the removed pinning setting absent.
+	settings, ok := values["defaultSettings"].(map[string]any)
+	if !ok {
+		t.Fatal("defaultSettings not found or not a map")
+	}
+	if settings["createDefaultDiskLabeledNodes"] != true {
+		t.Errorf("defaultSettings.createDefaultDiskLabeledNodes = %v, want true", settings["createDefaultDiskLabeledNodes"])
+	}
+	if settings["taintToleration"] != "node.longhorn.io/storage=true:NoSchedule" {
+		t.Errorf("defaultSettings.taintToleration = %v, want the storage taint", settings["taintToleration"])
+	}
+	if _, ok := settings["systemManagedComponentsNodeSelector"]; ok {
+		t.Error("defaultSettings.systemManagedComponentsNodeSelector must not be set (pinning removed, #366)")
+	}
+
 	// longhorn-manager and the driver must run on EVERY node so workloads can
 	// mount volumes anywhere (#366). They must therefore carry NO nodeSelector
 	// and a tolerate-all toleration.

--- a/pkg/storage/longhorn/longhorn_test.go
+++ b/pkg/storage/longhorn/longhorn_test.go
@@ -20,10 +20,11 @@ func boolPtr(b bool) *bool { return &b }
 
 func TestBuildHelmValues(t *testing.T) {
 	tests := []struct {
-		name        string
-		config      *Config
-		checkValues map[string]any
-		wantAbsent  []string // top-level keys that must NOT be set
+		name             string
+		config           *Config
+		checkValues      map[string]any
+		wantAbsent       []string // top-level keys that must NOT be set
+		wantAbsentNested []string // dotted nested paths that must NOT be set
 	}{
 		{
 			name:   "default config produces base values",
@@ -44,45 +45,15 @@ func TestBuildHelmValues(t *testing.T) {
 			},
 		},
 		{
-			name: "dedicated nodes adds nodeSelector and tolerations",
-			config: &Config{
-				DedicatedNodes: true,
-				NodeSelector:   map[string]string{"node.longhorn.io/storage": "true"},
-			},
-			checkValues: map[string]any{
-				"defaultSettings.createDefaultDiskLabeledNodes":       true,
-				"defaultSettings.taintToleration":                     "node.longhorn.io/storage=true:NoSchedule",
-				"defaultSettings.systemManagedComponentsNodeSelector": "node.longhorn.io/storage:true",
-			},
-		},
-		{
-			name:   "dedicated nodes without custom nodeSelector uses default",
+			name:   "dedicated nodes set disk + taint-toleration settings, not a node selector",
 			config: &Config{DedicatedNodes: true},
 			checkValues: map[string]any{
-				"defaultSettings.createDefaultDiskLabeledNodes":       true,
-				"defaultSettings.taintToleration":                     "node.longhorn.io/storage=true:NoSchedule",
-				"defaultSettings.systemManagedComponentsNodeSelector": "node.longhorn.io/storage:true",
+				"defaultSettings.createDefaultDiskLabeledNodes": true,
+				"defaultSettings.taintToleration":               "node.longhorn.io/storage=true:NoSchedule",
 			},
-		},
-		{
-			name: "dedicated nodes with custom multi-key nodeSelector derives sorted selector setting",
-			config: &Config{
-				DedicatedNodes: true,
-				NodeSelector:   map[string]string{"workload": "storage", "tier": "longhorn"},
-			},
-			checkValues: map[string]any{
-				"defaultSettings.systemManagedComponentsNodeSelector": "tier:longhorn;workload:storage",
-			},
-		},
-		{
-			name: "dedicated nodes with empty nodeSelector falls back to default label",
-			config: &Config{
-				DedicatedNodes: true,
-				NodeSelector:   map[string]string{},
-			},
-			checkValues: map[string]any{
-				"defaultSettings.systemManagedComponentsNodeSelector": "node.longhorn.io/storage:true",
-			},
+			// system components must NOT be pinned by node selector (#366);
+			// confinement comes from disks only existing on storage nodes.
+			wantAbsentNested: []string{"defaultSettings.systemManagedComponentsNodeSelector"},
 		},
 		{
 			name:   "non-dedicated nodes omits nodeSelector and tolerations",
@@ -126,6 +97,11 @@ func TestBuildHelmValues(t *testing.T) {
 					t.Errorf("key %q should not be set", key)
 				}
 			}
+			for _, key := range tt.wantAbsentNested {
+				if got := getNestedValue(values, key); got != nil {
+					t.Errorf("nested key %q should not be set, got %v", key, got)
+				}
+			}
 		})
 	}
 }
@@ -138,49 +114,30 @@ func TestBuildHelmValuesDedicatedNodesStructure(t *testing.T) {
 
 	values := buildHelmValues(cfg)
 
-	manager, ok := values["longhornManager"].(map[string]any)
-	if !ok {
-		t.Fatal("longhornManager not found or not a map")
-	}
-	// nodeSelector must be map[string]any, not map[string]string: Helm's value
-	// coalescing only treats map[string]any as a table (chartutil.istable), so
-	// a map[string]string nested here trips "cannot overwrite table with non
-	// table" against the chart's nodeSelector: {} default and the selector is
-	// dropped, leaving longhornManager/longhornDriver unpinned. See #365.
-	ns, ok := manager["nodeSelector"].(map[string]any)
-	if !ok {
-		t.Fatal("longhornManager.nodeSelector not found or not a map[string]any")
-	}
-	if ns["node.longhorn.io/storage"] != "true" {
-		t.Errorf("longhornManager.nodeSelector[node.longhorn.io/storage] = %q, want %q", ns["node.longhorn.io/storage"], "true")
-	}
-
-	tolerations, ok := manager["tolerations"].([]map[string]string)
-	if !ok {
-		t.Fatal("longhornManager.tolerations not found or not a []map[string]string")
-	}
-	if len(tolerations) != 1 {
-		t.Fatalf("longhornManager.tolerations length = %d, want 1", len(tolerations))
-	}
-	if tolerations[0]["key"] != "node.longhorn.io/storage" {
-		t.Errorf("toleration key = %q, want %q", tolerations[0]["key"], "node.longhorn.io/storage")
-	}
-	if tolerations[0]["operator"] != "Exists" {
-		t.Errorf("toleration operator = %q, want %q", tolerations[0]["operator"], "Exists")
-	}
-	if tolerations[0]["effect"] != "NoSchedule" {
-		t.Errorf("toleration effect = %q, want %q", tolerations[0]["effect"], "NoSchedule")
-	}
-
-	driver, ok := values["longhornDriver"].(map[string]any)
-	if !ok {
-		t.Fatal("longhornDriver not found or not a map")
-	}
-	if _, ok := driver["nodeSelector"].(map[string]any); !ok {
-		t.Fatal("longhornDriver.nodeSelector not found or not a map[string]any")
-	}
-	if _, ok := driver["tolerations"].([]map[string]string); !ok {
-		t.Fatal("longhornDriver.tolerations not found or not a []map[string]string")
+	// longhorn-manager and the driver must run on EVERY node so workloads can
+	// mount volumes anywhere (#366). They must therefore carry NO nodeSelector
+	// and a tolerate-all toleration.
+	for _, comp := range []string{"longhornManager", "longhornDriver"} {
+		c, ok := values[comp].(map[string]any)
+		if !ok {
+			t.Fatalf("%s not found or not a map", comp)
+		}
+		if _, ok := c["nodeSelector"]; ok {
+			t.Errorf("%s must not set a nodeSelector (pinning breaks workload-node mounts, #366)", comp)
+		}
+		tolerations, ok := c["tolerations"].([]map[string]any)
+		if !ok {
+			t.Fatalf("%s.tolerations not found or not a []map[string]any", comp)
+		}
+		if len(tolerations) != 1 {
+			t.Fatalf("%s.tolerations length = %d, want 1", comp, len(tolerations))
+		}
+		if tolerations[0]["operator"] != "Exists" {
+			t.Errorf("%s toleration operator = %v, want Exists", comp, tolerations[0]["operator"])
+		}
+		if _, ok := tolerations[0]["key"]; ok {
+			t.Errorf("%s toleration must have no key (tolerate-all), got %v", comp, tolerations[0]["key"])
+		}
 	}
 }
 
@@ -199,38 +156,6 @@ func TestBuildHelmValuesNonDedicatedOmitsSystemSettings(t *testing.T) {
 	}
 	if _, ok := settings["systemManagedComponentsNodeSelector"]; ok {
 		t.Error("defaultSettings.systemManagedComponentsNodeSelector should not be set when DedicatedNodes is false")
-	}
-}
-
-func TestFormatNodeSelector(t *testing.T) {
-	tests := []struct {
-		name     string
-		selector map[string]string
-		want     string
-	}{
-		{
-			name:     "single label",
-			selector: map[string]string{"node.longhorn.io/storage": "true"},
-			want:     "node.longhorn.io/storage:true",
-		},
-		{
-			name:     "multiple labels sorted by key",
-			selector: map[string]string{"workload": "storage", "tier": "longhorn"},
-			want:     "tier:longhorn;workload:storage",
-		},
-		{
-			name:     "empty selector",
-			selector: map[string]string{},
-			want:     "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := formatNodeSelector(tt.selector); got != tt.want {
-				t.Errorf("formatNodeSelector(%v) = %q, want %q", tt.selector, got, tt.want)
-			}
-		})
 	}
 }
 

--- a/pkg/storage/longhorn/storage_nodes.go
+++ b/pkg/storage/longhorn/storage_nodes.go
@@ -1,0 +1,77 @@
+package longhorn
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/otel"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/nebari-dev/nebari-infrastructure-core/pkg/status"
+)
+
+// StorageSelector returns the label set that identifies the dedicated Longhorn
+// storage node group: the configured NodeSelector, or the default
+// {NodeStorageLabel: "true"} when none is set. Providers use it to find which
+// of their node groups is the storage pool. Matching is an exact key/value
+// comparison, so the configured values are load-bearing.
+func StorageSelector(c *Config) map[string]string {
+	if c != nil && len(c.NodeSelector) > 0 {
+		return c.NodeSelector
+	}
+	return map[string]string{NodeStorageLabel: "true"}
+}
+
+// StorageNodeLabels returns every label a dedicated storage node group must
+// carry for Longhorn to work: the storage selector labels plus
+// CreateDefaultDiskLabel (so Longhorn auto-provisions a disk there). This is the
+// label contract a provider applies to its storage pool; the longhorn package
+// owns the policy, providers only apply it.
+func StorageNodeLabels(c *Config) map[string]string {
+	labels := map[string]string{CreateDefaultDiskLabel: "true"}
+	for k, v := range StorageSelector(c) {
+		labels[k] = v
+	}
+	return labels
+}
+
+// warnIfMissingStorageDiskLabel emits a loud warning when DedicatedNodes is set
+// but no node in the cluster carries CreateDefaultDiskLabel. Without that label,
+// createDefaultDiskLabeledNodes provisions zero disks and every volume faults
+// with ReplicaSchedulingFailure (#369). The AWS provider injects the label onto
+// storage node groups automatically; other providers (Hetzner, existing) must
+// label their storage pool themselves, and this check turns the otherwise-silent
+// failure into an actionable signal.
+func warnIfMissingStorageDiskLabel(ctx context.Context, kubeconfigBytes []byte, cfg *Config) error {
+	if cfg == nil || !cfg.DedicatedNodes {
+		return nil
+	}
+	client, err := newK8sClient(kubeconfigBytes)
+	if err != nil {
+		return fmt.Errorf("failed to create Kubernetes client: %w", err)
+	}
+	return warnIfMissingStorageDiskLabelWithClient(ctx, client, cfg)
+}
+
+func warnIfMissingStorageDiskLabelWithClient(ctx context.Context, client kubernetes.Interface, cfg *Config) error {
+	tracer := otel.Tracer("nebari-infrastructure-core")
+	ctx, span := tracer.Start(ctx, "longhorn.warnIfMissingStorageDiskLabel")
+	defer span.End()
+
+	nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{LabelSelector: CreateDefaultDiskLabel})
+	if err != nil {
+		span.RecordError(err)
+		return fmt.Errorf("failed to list nodes for storage-disk-label check: %w", err)
+	}
+	if len(nodes.Items) == 0 {
+		status.Send(ctx, status.NewUpdate(status.LevelWarning,
+			"dedicated_nodes is set but no node carries the "+CreateDefaultDiskLabel+
+				" label; Longhorn will create no disks and every volume will fault. "+
+				"Label your storage nodes with "+CreateDefaultDiskLabel+"=true "+
+				"(the AWS provider does this automatically).").
+			WithResource("longhorn").
+			WithAction("validating"))
+	}
+	return nil
+}

--- a/pkg/storage/longhorn/storage_nodes_test.go
+++ b/pkg/storage/longhorn/storage_nodes_test.go
@@ -1,0 +1,105 @@
+package longhorn
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/nebari-dev/nebari-infrastructure-core/pkg/status"
+)
+
+func TestStorageSelector(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *Config
+		want map[string]string
+	}{
+		{"nil config defaults to storage label", nil, map[string]string{"node.longhorn.io/storage": "true"}},
+		{"no selector defaults to storage label", &Config{}, map[string]string{"node.longhorn.io/storage": "true"}},
+		{"custom selector is returned", &Config{NodeSelector: map[string]string{"pool": "lh"}}, map[string]string{"pool": "lh"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StorageSelector(tt.cfg)
+			if len(got) != len(tt.want) {
+				t.Fatalf("StorageSelector() = %v, want %v", got, tt.want)
+			}
+			for k, v := range tt.want {
+				if got[k] != v {
+					t.Errorf("StorageSelector()[%q] = %q, want %q", k, got[k], v)
+				}
+			}
+		})
+	}
+}
+
+func TestStorageNodeLabels(t *testing.T) {
+	// Always includes the literal create-default-disk label wire value, plus the
+	// selector labels.
+	got := StorageNodeLabels(&Config{NodeSelector: map[string]string{"pool": "lh"}})
+	if got["node.longhorn.io/create-default-disk"] != "true" {
+		t.Errorf("StorageNodeLabels missing create-default-disk=true, got %v", got)
+	}
+	if got["pool"] != "lh" {
+		t.Errorf("StorageNodeLabels missing selector label pool=lh, got %v", got)
+	}
+
+	def := StorageNodeLabels(nil)
+	if def["node.longhorn.io/create-default-disk"] != "true" || def["node.longhorn.io/storage"] != "true" {
+		t.Errorf("StorageNodeLabels(nil) = %v, want default storage + create-default-disk labels", def)
+	}
+}
+
+func TestWarnIfMissingStorageDiskLabel(t *testing.T) {
+	node := func(name string, labels map[string]string) runtime.Object {
+		return &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels}}
+	}
+	tests := []struct {
+		name     string
+		nodes    []runtime.Object
+		wantWarn bool
+	}{
+		{
+			name:     "no node carries the disk label warns",
+			nodes:    []runtime.Object{node("a", map[string]string{"node.longhorn.io/storage": "true"})},
+			wantWarn: true,
+		},
+		{
+			name:     "a node with the disk label stays quiet",
+			nodes:    []runtime.Object{node("a", map[string]string{"node.longhorn.io/create-default-disk": "true"})},
+			wantWarn: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := fake.NewSimpleClientset(tt.nodes...) //nolint:staticcheck
+
+			var mu sync.Mutex
+			var warned bool
+			ctx, cleanup := status.StartHandler(context.Background(), func(u status.Update) {
+				if u.Level == status.LevelWarning && strings.Contains(u.Message, "create-default-disk") {
+					mu.Lock()
+					warned = true
+					mu.Unlock()
+				}
+			})
+
+			if err := warnIfMissingStorageDiskLabelWithClient(ctx, client, &Config{DedicatedNodes: true}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			cleanup()
+
+			mu.Lock()
+			defer mu.Unlock()
+			if warned != tt.wantWarn {
+				t.Errorf("warned = %v, want %v", warned, tt.wantWarn)
+			}
+		})
+	}
+}


### PR DESCRIPTION
resolves #354 

## What

Refactors NIC's Longhorn `dedicated_nodes` to the intended topology: **replica data only on dedicated storage nodes, but the volume-serving system pods on every node.** Fully fixes #369 and #366. Supersedes this branch's original cosmetic-warning fix for #365 — that warning is moot now (the nodeSelector it concerned is removed, not corrected).

## The bugs (live-cluster confirmed)

- **#366 (P1):** NIC pinned `longhorn-csi-plugin` + `longhorn-manager` + instance-managers to storage nodes → pods on `user`/`general`/`gpu` nodes failed to mount (`CSINode … does not contain driver driver.longhorn.io`).
- **#369 (P1):** storage nodes never got `node.longhorn.io/create-default-disk=true` → zero disks → every volume `detached/faulted` with `ReplicaSchedulingFailure`.

## Changes

- **`pkg/storage/longhorn/install.go`** — `buildHelmValues` for `dedicated_nodes` no longer sets `systemManagedComponentsNodeSelector` or a `nodeSelector` on `longhornManager`/`longhornDriver`; their tolerations become tolerate-all (`{operator: Exists}`), same rationale as the iSCSI prerequisite DaemonSet. `taintToleration` is set to `":"` so the system-managed components (csi-plugin, instance-managers, engine-image, share-manager) tolerate every taint and run on tainted workload pools too; `createDefaultDiskLabeledNodes` stays. Replica confinement now comes from disks existing only on storage nodes. Removed the dead `formatNodeSelector`.
- **`pkg/storage/longhorn/storage_nodes.go`** (new) — `StorageSelector(cfg)` / `StorageNodeLabels(cfg)` own the storage-node label policy in the shared package, and `warnIfMissingStorageDiskLabel` warns (post install/upgrade) when `dedicated_nodes` is set but no node carries the disk label — turning the silent non-AWS fault into an actionable signal.
- **`pkg/provider/aws/tofu.go`** — injects `node.longhorn.io/create-default-disk=true` onto node groups matching the storage selector (via the shared helpers), applied by kubelet at node registration (autoscaler-safe). `pkg/storage/longhorn` stays provider-agnostic.
- **`pkg/storage/longhorn/config.go`** — export `NodeStorageLabel` + `CreateDefaultDiskLabel`, document the disk-label contract + exact-value-match semantics; `NodeSelector` now identifies the storage pool (no longer pins components).
- **`examples/aws-config.yaml`** — show the `create-default-disk` label; fix the stale "pins Longhorn" comments.
- **`docs/adr/0002`** — update the dedicated-nodes Helm-values block + a 2026-06 note recording the topology change and its limitations.
- Tests: full dedicated-nodes contract assertion, shared-helper tables, the disk-label warn guard, and AWS edge cases (multiple storage groups, idempotency, no-mutation, literal wire value).

## Scope of the issue fixes

**`Closes #369` — fully (AWS).** The disk label lands on storage nodes via the AWS injection, autoscaler-safe, tested. Non-AWS providers must label their storage pool themselves; the new guard warns when they haven't. Follow-up tracked for cross-provider parity.

**`Closes #366` — fully.** Mounts work on every workload node, untainted or tainted. The system-managed `longhorn-csi-plugin` tolerates every taint via `taintToleration: ":"` (merged from #372), so a `nvidia.com/gpu:NoSchedule` pool runs csi-plugin and PVC pods mount there. Replica data stays on the storage nodes because only they carry a Longhorn disk.

One #366 DoD item is intentionally not implemented as written: the controller that reconciles `allowScheduling:false` on non-storage Node CRs. Disk-confinement replaces it (non-storage nodes have no disk, so replicas cannot land there), which is simpler and autoscaler-safe. The trade-off is that confinement is an emergent property (no disk) rather than an explicit guard.

## Note on the tolerate-all change

The tolerate-all settings (`{operator: Exists}` on manager/driver, and `taintToleration: ":"` for the system-managed components) put privileged Longhorn pods on control-plane, GPU, and any tainted nodes. Intended for managed control planes (EKS) and consistent with the iSCSI DaemonSet precedent; on bring-your-own clusters with reachable masters it lands storage infra there.

## Testing

- `go build ./...`, `go vet ./...`, `go test ./...` (incl. `-race`), `gofmt -l` all clean.
- Verified end-to-end on a live EKS cluster (storage x2 tainted+labeled, an untainted general pool, and a tainted non-storage pool): csi-plugin and instance-manager run on every node, disks exist only on the storage nodes, all replicas are confined to the storage nodes, and PVC pods mount on both an untainted and a tainted node with data readable. Volumes that had faulted before the disk fix self-healed once the disks appeared.

Closes #369
Closes #366
