### PR TITLE
feat(aws): auto-apply nvidia.com/gpu taint to GPU node groups

### DIFF
--- a/docs/design-doc/appendix/16-configuration-reference.md
+++ b/docs/design-doc/appendix/16-configuration-reference.md
@@ -181,17 +181,19 @@ amazon_web_services:
       max_nodes: 10
       taints: []
 
-    # GPU node group example
+    # GPU node group example.
+    # With gpu: true, NIC selects the AL2023_x86_64_NVIDIA AMI and automatically
+    # applies the taint nvidia.com/gpu=true:NO_SCHEDULE so only pods that
+    # tolerate it land on GPU nodes. The NVIDIA GPU Operator does not taint
+    # nodes itself; it only tolerates this taint on its own operands. To use a
+    # different value or effect, set an explicit nvidia.com/gpu taint below and
+    # NIC leaves it untouched.
     gpu:
       instance: g5.2xlarge
       min_nodes: 0
       max_nodes: 5
       gpu: true
       spot: false
-      taints:
-        - key: nvidia.com/gpu
-          value: "true"
-          effect: NoSchedule
 
     # Spot instance node group example
     spot-workers:

--- a/examples/aws-config.yaml
+++ b/examples/aws-config.yaml
@@ -75,7 +75,10 @@ cluster:
       #   instance: g5.xlarge
       #   min_nodes: 0
       #   max_nodes: 3
-      #   gpu: true # Uses AL2023_x86_64_NVIDIA AMI
+      #   gpu: true # Uses AL2023_x86_64_NVIDIA AMI and auto-applies the
+      #             # nvidia.com/gpu=true:NO_SCHEDULE taint (set your own
+      #             # nvidia.com/gpu taint to override). GPU workloads must
+      #             # tolerate it; the NVIDIA GPU Operator tolerates it already.
       #
       # # Example: ARM64 Graviton node group
       # graviton:

--- a/pkg/provider/aws/tofu.go
+++ b/pkg/provider/aws/tofu.go
@@ -14,6 +14,11 @@ const (
 	longhornWebhookConversionKey = "longhorn_webhook_conversion"
 )
 
+// gpuTaintKey is the taint key applied to GPU node groups. It matches the key
+// the NVIDIA GPU Operator's operands tolerate out of the box, so operator
+// components keep scheduling while ordinary pods are kept off GPU nodes.
+const gpuTaintKey = "nvidia.com/gpu"
+
 type TFVars struct {
 	Region                        string               `json:"region"`
 	ProjectName                   string               `json:"project_name,omitempty"`
@@ -49,7 +54,10 @@ type TFVars struct {
 	EnableIRSA                         *bool `json:"enable_irsa,omitempty"`
 }
 
-func resolveNodeGroupAMIs(nodeGroups map[string]NodeGroup) map[string]NodeGroup {
+// resolveNodeGroupDefaults derives per-node-group defaults from the parsed
+// config: the EKS AMI type (NVIDIA for GPU groups, standard otherwise) and the
+// GPU taint. It returns a new map and never mutates the caller's node groups.
+func resolveNodeGroupDefaults(nodeGroups map[string]NodeGroup) map[string]NodeGroup {
 	result := make(map[string]NodeGroup, len(nodeGroups))
 	for name, group := range nodeGroups {
 		if group.AMIType == nil {
@@ -62,9 +70,32 @@ func resolveNodeGroupAMIs(nodeGroups map[string]NodeGroup) map[string]NodeGroup 
 			}
 			group.AMIType = &ami
 		}
-		result[name] = group
+		result[name] = applyGPUTaint(group)
 	}
 	return result
+}
+
+// applyGPUTaint ensures a GPU node group carries the nvidia.com/gpu taint so
+// that only pods tolerating it schedule onto GPU hardware. The NVIDIA GPU
+// Operator does not taint nodes itself; it only tolerates this taint on its own
+// operands, so applying it is the caller's responsibility. A node group that
+// already has an nvidia.com/gpu taint (any value or effect) is left untouched.
+// The returned group never shares its Taints backing array with the input, so
+// the caller's config is not mutated.
+func applyGPUTaint(group NodeGroup) NodeGroup {
+	if !group.GPU {
+		return group
+	}
+	for _, t := range group.Taints {
+		if t.Key == gpuTaintKey {
+			return group
+		}
+	}
+	taints := make([]Taint, len(group.Taints), len(group.Taints)+1)
+	copy(taints, group.Taints)
+	taints = append(taints, Taint{Key: gpuTaintKey, Value: "true", Effect: "NO_SCHEDULE"})
+	group.Taints = taints
+	return group
 }
 
 func (c *Config) toTFVars(projectName string) (TFVars, error) {
@@ -80,7 +111,7 @@ func (c *Config) toTFVars(projectName string) (TFVars, error) {
 		EndpointPublicAccess:   c.EndpointPublicAccess,
 		ClusterEnabledLogTypes: c.EnabledLogTypes,
 		CreateIAMRoles:         c.ExistingClusterRoleArn == "" && c.ExistingNodeRoleArn == "",
-		NodeGroups:             resolveNodeGroupAMIs(c.NodeGroups),
+		NodeGroups:             resolveNodeGroupDefaults(c.NodeGroups),
 		// Only provision the autoscaler's IAM role / pod identity association
 		// when the autoscaler itself will be installed (see provider deploy).
 		EnableClusterAutoscalerPodIdentity: c.ClusterAutoscalerEnabled(),

--- a/pkg/provider/aws/tofu_test.go
+++ b/pkg/provider/aws/tofu_test.go
@@ -153,7 +153,7 @@ func TestToTFVarsLonghornSGRulePorts(t *testing.T) {
 	}
 }
 
-func TestResolveNodeGroupAMIs(t *testing.T) {
+func TestResolveNodeGroupDefaultsAMIs(t *testing.T) {
 	nvidiaAMI := "AL2023_x86_64_NVIDIA"
 	standardAMI := "AL2023_x86_64_STANDARD"
 	customAMI := "AL2023_ARM_64_NVIDIA"
@@ -214,7 +214,7 @@ func TestResolveNodeGroupAMIs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := resolveNodeGroupAMIs(tt.input)
+			result := resolveNodeGroupDefaults(tt.input)
 
 			for name, expectedAMI := range tt.expected {
 				g, ok := result[name]
@@ -239,12 +239,119 @@ func TestResolveNodeGroupAMIs(t *testing.T) {
 			"gpu":    {Instance: "g4dn.xlarge", GPU: true},
 			"worker": {Instance: "m7i.xlarge"},
 		}
-		resolveNodeGroupAMIs(original)
+		resolveNodeGroupDefaults(original)
 		if original["gpu"].AMIType != nil {
-			t.Error("resolveNodeGroupAMIs mutated the gpu node group in the input map")
+			t.Error("resolveNodeGroupDefaults mutated the gpu node group in the input map")
 		}
 		if original["worker"].AMIType != nil {
-			t.Error("resolveNodeGroupAMIs mutated the worker node group in the input map")
+			t.Error("resolveNodeGroupDefaults mutated the worker node group in the input map")
+		}
+	})
+}
+
+func TestResolveNodeGroupGPUTaints(t *testing.T) {
+	const gpuTaintKey = "nvidia.com/gpu"
+
+	// countTaintsWithKey returns how many taints in the group use the given key.
+	countTaintsWithKey := func(g NodeGroup, key string) int {
+		n := 0
+		for _, taint := range g.Taints {
+			if taint.Key == key {
+				n++
+			}
+		}
+		return n
+	}
+
+	tests := []struct {
+		name       string
+		input      map[string]NodeGroup
+		group      string
+		wantGPU    *Taint // expected nvidia.com/gpu taint, or nil if none expected
+		wantTaints int    // total taint count expected on the group
+	}{
+		{
+			name: "gpu node group without taints gets the standard gpu taint",
+			input: map[string]NodeGroup{
+				"gpu": {Instance: "g4dn.xlarge", GPU: true},
+			},
+			group:      "gpu",
+			wantGPU:    &Taint{Key: gpuTaintKey, Value: "true", Effect: "NO_SCHEDULE"},
+			wantTaints: 1,
+		},
+		{
+			name: "gpu node group with an existing gpu taint is left untouched",
+			input: map[string]NodeGroup{
+				"gpu": {Instance: "g4dn.xlarge", GPU: true, Taints: []Taint{
+					{Key: gpuTaintKey, Value: "present", Effect: "NO_EXECUTE"},
+				}},
+			},
+			group:      "gpu",
+			wantGPU:    &Taint{Key: gpuTaintKey, Value: "present", Effect: "NO_EXECUTE"},
+			wantTaints: 1,
+		},
+		{
+			name: "gpu node group with an unrelated taint keeps it and gains the gpu taint",
+			input: map[string]NodeGroup{
+				"gpu": {Instance: "g4dn.xlarge", GPU: true, Taints: []Taint{
+					{Key: "dedicated", Value: "ml", Effect: "NO_SCHEDULE"},
+				}},
+			},
+			group:      "gpu",
+			wantGPU:    &Taint{Key: gpuTaintKey, Value: "true", Effect: "NO_SCHEDULE"},
+			wantTaints: 2,
+		},
+		{
+			name: "non-gpu node group gets no taint",
+			input: map[string]NodeGroup{
+				"worker": {Instance: "m7i.xlarge"},
+			},
+			group:      "worker",
+			wantGPU:    nil,
+			wantTaints: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resolveNodeGroupDefaults(tt.input)
+			g := result[tt.group]
+
+			if got := len(g.Taints); got != tt.wantTaints {
+				t.Errorf("taint count = %d, want %d (taints: %+v)", got, tt.wantTaints, g.Taints)
+			}
+
+			if got := countTaintsWithKey(g, gpuTaintKey); got > 1 {
+				t.Errorf("found %d %q taints, want at most 1", got, gpuTaintKey)
+			}
+
+			var gpuTaint *Taint
+			for i := range g.Taints {
+				if g.Taints[i].Key == gpuTaintKey {
+					gpuTaint = &g.Taints[i]
+					break
+				}
+			}
+			switch {
+			case tt.wantGPU == nil && gpuTaint != nil:
+				t.Errorf("expected no %q taint, got %+v", gpuTaintKey, *gpuTaint)
+			case tt.wantGPU != nil && gpuTaint == nil:
+				t.Errorf("expected %q taint %+v, got none", gpuTaintKey, *tt.wantGPU)
+			case tt.wantGPU != nil && *gpuTaint != *tt.wantGPU:
+				t.Errorf("gpu taint = %+v, want %+v", *gpuTaint, *tt.wantGPU)
+			}
+		})
+	}
+
+	t.Run("does not mutate input taints", func(t *testing.T) {
+		original := map[string]NodeGroup{
+			"gpu": {Instance: "g4dn.xlarge", GPU: true, Taints: []Taint{
+				{Key: "dedicated", Value: "ml", Effect: "NO_SCHEDULE"},
+			}},
+		}
+		resolveNodeGroupDefaults(original)
+		if got := len(original["gpu"].Taints); got != 1 {
+			t.Errorf("input gpu node group taints mutated: len = %d, want 1", got)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

AWS node groups with `gpu: true` now get the taint `nvidia.com/gpu=true:NO_SCHEDULE` applied automatically, so ordinary pods stay off GPU nodes without anyone hand-writing taint config.

This corrects a common misconception: the NVIDIA GPU Operator does not taint GPU nodes itself. It only ships a toleration for `nvidia.com/gpu` on its own operands, so applying the taint is the platform's job. See [NVIDIA/gpu-operator#26](https://github.com/NVIDIA/gpu-operator/issues/26).

Closes #368.

> [!WARNING]
> **Blocked.** On EKS nothing auto-injects the `nvidia.com/gpu` toleration (the GPU Operator only tolerates the taint on its own operands, and `ExtendedResourceToleration` is not available on EKS). So once this taint lands, GPU workloads in our software packs will stop scheduling onto GPU nodes until each pack tolerates `nvidia.com/gpu`. This PR must not merge until all three are resolved:
>
> - [ ] nebari-dev/nebari-data-science-pack#117 - GPU JupyterHub profiles tolerate the taint
> - [x] nebari-dev/nebari-llm-serving-pack#88 - GPU serving workloads tolerate the taint
> - [x] nebari-dev/nebari-rayserve-pack#14 - Ray Serve GPU workloads tolerate the taint

## What changed

- `pkg/provider/aws/tofu.go`: new `applyGPUTaint` helper and `gpuTaintKey` const. Renamed `resolveNodeGroupAMIs` to `resolveNodeGroupDefaults` since it now resolves both the AMI type and the taint.
- An existing `nvidia.com/gpu` taint (any value or effect) is left untouched; unrelated taints are preserved alongside the GPU taint. The source config is never mutated (the `Taints` slice is copied before appending).
- Scope is AWS only. GKE already auto-taints GPU pools with `nvidia.com/gpu=present:NoSchedule`, so doing the same on GCP would double-taint. Azure is out of scope.
- Docs: `examples/aws-config.yaml` and `docs/design-doc/appendix/16-configuration-reference.md` updated. The reference doc previously showed `effect: NoSchedule`, which is the wrong enum form for the EKS path; that block is removed in favor of the automatic taint.

## Automated checks

- `go test ./...` passes
- `golangci-lint run` (v2): 0 issues
- `go vet` and `gofmt`: clean
- New table-driven tests in `tofu_test.go`: no-taints, existing-gpu-taint-untouched, unrelated-taint-kept, non-gpu, and a no-mutation check.

## Manual test plan

The plan has two goals: (1) confirm the taint is applied and behaves correctly, and (2) confirm nothing else regresses, including existing clusters on upgrade.

### Part 0 - Variable generation (local, no cloud)

1. `make build`.
2. Run a deploy/plan against a config containing a `gpu: true` node group and inspect the generated Terraform variables (or run `tofu plan` in the working dir). Confirm the GPU node group's `taints` includes `{key: nvidia.com/gpu, value: "true", effect: NO_SCHEDULE}` and that non-GPU groups have no such taint.

### Part 1 - Taint applied as intended (AWS, real or staging EKS)

0. **End-to-end JupyterHub GPU profile (primary use case):** with a `gpu: true` node group deployed and tainted, log into JupyterHub and launch a GPU profile that uses the data science software pack. Confirm the server pod schedules onto the GPU node and starts. This only works if the GPU profile carries a toleration for `nvidia.com/gpu`, so as part of this check verify the profile's KubeSpawner config includes that toleration (and a matching nodeSelector). Inside the running server, confirm the GPU is visible (for example `nvidia-smi` returns the device, and a framework such as PyTorch/TensorFlow reports CUDA available). This is the headline scenario: the taint must keep non-GPU pods off the node while still letting the GPU notebook server land on it.
1. **Fresh GPU group, no taints set:** deploy a config with a `gpu: true` node group and no `taints:` block. After the node joins, run `kubectl describe node <gpu-node>` and confirm the taint `nvidia.com/gpu=true:NoSchedule` is present.
2. **Pod without toleration is repelled:** schedule a plain pod with a GPU nodeSelector but no toleration. Confirm it stays `Pending` and does not land on the GPU node.
3. **Pod with toleration schedules:** schedule the same pod with a toleration for `nvidia.com/gpu`. Confirm it schedules onto the GPU node.
4. **GPU Operator still works:** if the NVIDIA GPU Operator is installed, confirm its operands (driver daemonset, device plugin, DCGM) still schedule on the tainted node, since they tolerate the key out of the box. Confirm `nvidia.com/gpu` shows up as allocatable on the node.
5. **Override is respected:** set an explicit `nvidia.com/gpu` taint with a different value/effect (for example `value: present`, `effect: NO_EXECUTE`) on a `gpu: true` group. Confirm NIC leaves it untouched, with no duplicate `nvidia.com/gpu` taint.
6. **Unrelated taint preserved:** set an unrelated taint (for example `dedicated=ml:NO_SCHEDULE`) on a `gpu: true` group. Confirm both that taint and the auto GPU taint are present on the node.

### Part 2 - Does not break anything else (regression)

1. **Non-GPU node groups unaffected:** deploy a config with only standard node groups. Confirm nodes get the standard AMI, no `nvidia.com/gpu` taint, and ordinary pods schedule normally.
2. **Existing taints on non-GPU groups unchanged:** with a Longhorn storage node group (`node.longhorn.io/storage=true:NO_SCHEDULE`), confirm that taint is unchanged and no GPU taint is added.
3. **Idempotency / no churn:** run the deploy twice against an unchanged config. Confirm the second `tofu plan` shows no changes for the GPU node group (no taint add/remove churn).
4. **Upgrade of a cluster with pre-existing untainted GPU nodes (IMPORTANT migration check):** take a cluster that already runs `gpu: true` nodes provisioned before this change (so they currently have no taint). Re-run deploy. Expect the taint to be newly added to the GPU node group. Verify what happens to GPU workloads already running there that lack a matching toleration: with `NoSchedule` they keep running but new untolerated pods will not schedule; confirm no unexpected eviction. The most likely affected workload is the JupyterHub GPU profile: a profile that previously scheduled onto an untainted GPU node with no toleration will stop scheduling new servers once the taint is in place. Confirm the GPU profile tolerates `nvidia.com/gpu` and document this in upgrade notes so operators add the toleration before upgrading.
5. **Full suite:** `go test ./...`, `golangci-lint run`, `go vet ./...` all green.

### Rollback

Revert the commit; existing node groups keep whatever taints are in their config. Nodes provisioned with the auto taint retain it until the node group is replaced or the taint is removed in config.
