### PR TITLE
fix(longhorn): unpin system pods for dedicated_nodes, restrict replicas via Node CRs (#366)

### DIFF
--- a/pkg/storage/longhorn/config.go
+++ b/pkg/storage/longhorn/config.go
@@ -92,12 +92,10 @@ type Config struct {
 	// exact values set here.
 	//
 	// Constraint: the taint toleration is NOT derived from this field. Longhorn's
-	// system components always tolerate the fixed taint
-	// node.longhorn.io/storage=true:NoSchedule (see nodeStorageTaintToleration in
-	// install.go). If you customize this selector, the storage nodes must still
-	// carry that exact taint, or the replica-role components can't run there.
-	// Parameterizing the taint is tracked in
-	// nebari-dev/nebari-infrastructure-core#363.
+	// system components tolerate every taint (see tolerateAllTaints in install.go),
+	// so the storage nodes' taint - and any taint on a workload pool where a PVC
+	// must mount - is covered regardless of what you set here. This selector only
+	// controls which nodes are labeled as the storage (replica) pool.
 	NodeSelector map[string]string `yaml:"node_selector,omitempty"`
 
 	// ClusterAutoscalerEnabled tells Longhorn whether the cluster runs the

--- a/pkg/storage/longhorn/install.go
+++ b/pkg/storage/longhorn/install.go
@@ -18,14 +18,19 @@ import (
 
 const installTimeout = 10 * time.Minute
 
-// nodeStorageTaintToleration is the Longhorn taint-toleration setting value
-// matching the recommended dedicated-node taint
-// (node.longhorn.io/storage=true:NoSchedule). This setting is what lets
-// Longhorn's system-managed components (instance-manager, engine-image,
-// CSI plugin) tolerate the storage-node taint so the replica-serving
-// components can run on the dedicated storage nodes.
+// tolerateAllTaints is the Longhorn taint-toleration setting value that tells
+// Longhorn's system-managed components (longhorn-csi-plugin, the replica/engine
+// instance-managers, engine-image, share-manager) to tolerate EVERY taint.
+// Longhorn parses the bare ":" as a toleration with an empty key and
+// Operator=Exists, which matches all taints regardless of key, value, or effect.
+// The csi-plugin is the per-node mount driver, so it must run on every node a
+// workload pod might land on - including tainted pools (the storage taint, a GPU
+// pool's nvidia.com/gpu:NoSchedule, any config-driven taint) - or PVC mounts
+// fail there (#366). Replica DATA is still confined to storage nodes because
+// only they carry CreateDefaultDiskLabel and thus get a Longhorn disk (#369).
+// https://github.com/longhorn/longhorn-manager/blob/v1.11.2/types/setting.go
 // https://longhorn.io/docs/1.11.2/advanced-resources/deploy/taint-toleration/
-const nodeStorageTaintToleration = NodeStorageLabel + "=true:NoSchedule"
+const tolerateAllTaints = ":"
 
 // Install installs (or upgrades, if a release exists) Longhorn on the cluster
 // the kubeconfigBytes connect to.
@@ -241,22 +246,19 @@ func buildHelmValues(cfg *Config) map[string]any {
 		// nodes and broke PVC mounts there (#366).
 		settings["createDefaultDiskLabeledNodes"] = true
 
-		// System-managed components (replica-role instance-managers, engine-image,
-		// share-manager) must tolerate the storage-node taint so they can run on
-		// the dedicated storage nodes that host replicas.
-		settings["taintToleration"] = nodeStorageTaintToleration
+		// System-managed components - crucially the per-node longhorn-csi-plugin,
+		// plus the replica/engine instance-managers, engine-image and share-manager
+		// - tolerate EVERY taint via the tolerate-all taintToleration. The csi-plugin
+		// must run wherever a workload pod can be scheduled, including tainted pools
+		// (storage taint, a GPU pool's nvidia.com/gpu:NoSchedule, any config-driven
+		// taint), or PVC mounts fail there (#366). Replica DATA stays on storage
+		// nodes regardless, because only they get a Longhorn disk (#369).
+		settings["taintToleration"] = tolerateAllTaints
 
 		// longhorn-manager (DaemonSet) and the driver deployer are node-level
-		// infrastructure, not workloads, so they tolerate all taints (same
+		// infrastructure, not workloads, so they also tolerate all taints (same
 		// rationale as the embedded iSCSI prerequisite DaemonSet) and carry no
-		// nodeSelector (#366). NOTE: the per-node *mount* component,
-		// longhorn-csi-plugin, is system-managed — its tolerations come from the
-		// taintToleration setting above (storage taint only), NOT from these
-		// manager/driver tolerations. So mounts work on untainted workload nodes
-		// and on the storage nodes, but a *tainted* workload pool (e.g. a GPU pool
-		// with nvidia.com/gpu:NoSchedule) would need its taint added to
-		// taintToleration for csi-plugin to land there. Tracked as a follow-up
-		// (relates to #363/#368).
+		// nodeSelector (#366).
 		tolerateAll := []map[string]any{{"operator": "Exists"}}
 		values["longhornManager"] = map[string]any{"tolerations": tolerateAll}
 		values["longhornDriver"] = map[string]any{"tolerations": tolerateAll}

--- a/pkg/storage/longhorn/longhorn_test.go
+++ b/pkg/storage/longhorn/longhorn_test.go
@@ -45,11 +45,11 @@ func TestBuildHelmValues(t *testing.T) {
 			},
 		},
 		{
-			name:   "dedicated nodes set disk + taint-toleration settings, not a node selector",
+			name:   "dedicated nodes set disk + tolerate-all taint setting, not a node selector",
 			config: &Config{DedicatedNodes: true},
 			checkValues: map[string]any{
 				"defaultSettings.createDefaultDiskLabeledNodes": true,
-				"defaultSettings.taintToleration":               "node.longhorn.io/storage=true:NoSchedule",
+				"defaultSettings.taintToleration":               ":",
 			},
 			// system components must NOT be pinned by node selector (#366);
 			// confinement comes from disks only existing on storage nodes.
@@ -123,8 +123,8 @@ func TestBuildHelmValuesDedicatedNodesStructure(t *testing.T) {
 	if settings["createDefaultDiskLabeledNodes"] != true {
 		t.Errorf("defaultSettings.createDefaultDiskLabeledNodes = %v, want true", settings["createDefaultDiskLabeledNodes"])
 	}
-	if settings["taintToleration"] != "node.longhorn.io/storage=true:NoSchedule" {
-		t.Errorf("defaultSettings.taintToleration = %v, want the storage taint", settings["taintToleration"])
+	if settings["taintToleration"] != ":" {
+		t.Errorf("defaultSettings.taintToleration = %v, want \":\" (tolerate all taints)", settings["taintToleration"])
 	}
 	if _, ok := settings["systemManagedComponentsNodeSelector"]; ok {
 		t.Error("defaultSettings.systemManagedComponentsNodeSelector must not be set (pinning removed, #366)")


### PR DESCRIPTION
## Closes

Closes #366
Closes #365
Related #354 

## Description

`dedicated_nodes: true` is meant to keep Longhorn replicas on a dedicated storage node group. The old implementation did that by pinning Longhorn's *system pods* to the storage nodes through three knobs in `buildHelmValues`: the `system-managed-components-node-selector` setting, `longhornManager.nodeSelector`, and `longhornDriver.nodeSelector`.

That pins the wrong things. The `longhorn-csi-plugin` DaemonSet and the engine-role `instance-manager` have to run on every node where a pod might mount a Longhorn PVC, not only on the storage nodes. With the selectors in place, any pod scheduled on a `user`/`general`/`gpu-t4` node fails to mount its volume (`CSINode ... does not contain driver driver.longhorn.io`, then `volume ... is not ready for workloads`). That is a P1 break of the feature.

This switches to Longhorn's intended pattern for dedicated storage nodes: run all system pods cluster-wide, and restrict only *replica placement* to the storage nodes.

What changed:

- **Stop pinning (helm values).** Drop `systemManagedComponentsNodeSelector` and the `nodeSelector` on `longhornManager`/`longhornDriver`. Give the manager and driver a blanket `{operator: Exists}` toleration, and set the system-component `taintToleration` to `":"`, which Longhorn parses as `{Key:"", Operator:Exists, Effect:""}`, tolerating every taint. The CSI plugin, manager, driver, and engine instance-managers now run on every node regardless of node-group taint (storage taint, GPU taint, any config-driven taint).
- **Restrict replicas (new post-install step).** `reconcileNodeScheduling` runs after install and upgrade when `dedicated_nodes` is on. It sets `spec.allowScheduling: true` on the Longhorn `Node` CR of each storage node and `false` on every other node, so replicas only land on storage nodes. It waits for the CRs to appear (longhorn-manager creates them asynchronously) and fails the deploy if it cannot finish or if no storage node is labeled.

Because the fix lives in the helm-rendered values rather than a live `kubectl patch`, it survives the longhorn-manager pod-restart re-import that made the manual workaround revert.

This also resolves #365: that warning came from `longhornManager.nodeSelector` / `longhornDriver.nodeSelector` arriving as empty maps. Those keys are no longer emitted on this path, so the warning cannot occur.

**Supersedes #367.** That PR fixes the cosmetic coalescing warning (#365) by making the `nodeSelector` map type apply cleanly, but it cements the pinning this PR removes. #367 is a pull request, so merging this one will not close it automatically; it should be closed manually.

### Deferred to follow-ups

- The `Node` CR reconcile is one-shot, at deploy time. Nodes the autoscaler adds *between* deploys still come up with `allowScheduling: true`, so a controller is needed to reconcile them on node-join. Tracked in #371. This does not block the PR: the P1 mount break is fixed for every node present at deploy time.
- The storage node group lacks the `node.longhorn.io/create-default-disk` label, tracked in #369.

## How to Test

### Automated

`go test ./pkg/storage/longhorn/...` (also runs under `go test ./... -race`).

- `TestBuildHelmValues` / `TestBuildHelmValuesDedicatedNodesStructure`: with `dedicated_nodes: true`, the rendered values carry no `systemManagedComponentsNodeSelector`, no `longhornManager`/`longhornDriver` nodeSelector, a bare `{operator: Exists}` toleration on manager and driver, and `taintToleration: ":"`.
- `TestReconcileNodeSchedulingWithClients` (fake typed + dynamic clients):
  - mixed nodes: storage nodes get `allowScheduling: true`, others `false`
  - custom multi-label selector partitions on all labels
  - no storage nodes: returns an error (deploy fails)
  - Node CR never appears: times out with an error
  - non-NotFound patch error: returned immediately, no retry

### Manual (live cluster)

The mount behavior unit tests cannot prove. On a cluster with a tainted and labeled `storage` node group plus at least one `user`/`general`/`gpu` group:

1. `nic deploy -f config.yaml` with `longhorn.dedicated_nodes: true`.
2. CSI plugin runs everywhere: `kubectl -n longhorn-system get pods -l app=longhorn-csi-plugin -o wide` shows one pod per node, including non-storage nodes.
3. The system setting is cleared: `kubectl -n longhorn-system get settings.longhorn.io system-managed-components-node-selector -o jsonpath='{.value}'` is empty.
4. Replica scheduling is restricted: `kubectl -n longhorn-system get nodes.longhorn.io -o custom-columns=NAME:.metadata.name,SCHED:.spec.allowScheduling` shows `true` only on storage nodes.
5. A PVC pod mounts on a non-storage node: schedule a pod with a Longhorn PVC onto a `user`/`gpu` node; it reaches `Running` with no `FailedAttachVolume` or `not ready for workloads` events.
6. Replicas stay on storage nodes: `kubectl -n longhorn-system get replicas.longhorn.io -o wide` shows all replicas on storage nodes.
7. Re-run `nic deploy`; the reconcile is idempotent and the setting and CRs stay correct after manager pods cycle (no revert).
8. Tainted GPU node: confirm the CSI plugin and an engine instance-manager land there and a PVC pod on that node mounts.
