### PR TITLE
Remove duplicate CLI error logging and usage output on failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,6 +312,8 @@ func SomeFunction(ctx context.Context, ...) error {
 - Use `slog.Info()` / `slog.Error()` in `cmd/nic/` commands.
 - Do **not** log in `pkg/` library code; emit spans and status updates instead.
 
+**Inside a `RunE`, do not `slog.Error` an error you also return**. Record it on the span (`span.RecordError(err)`) and return it (wrapped where useful); `main()` logs returned errors exactly once, so logging *and* returning duplicates the report (see #326).
+
 **The status channel is the seam.** `pkg/` code surfaces user-visible progress by sending `status.Update`s through the channel attached to ctx (see `pkg/status`). Translation of updates into slog records lives in `pkg/nic/status.go` (`SlogHandler` / `StartSlogHandler`); `cmd/nic` wires it up via `nic.StartSlogHandler` and remains the only layer that emits logs. When wrapping a subprocess that emits structured output (e.g. `tofu -json`, `hetzner-k3s`), use `status.NewWriter` with a `LineMapper` that produces one `Update` per line; the full structured event should ride through as `Update.Metadata[status.MetadataKeyPayload]` so handlers can decode any sub-field without the producer enumerating them.
 
 ## Key Development Patterns

--- a/cmd/nic/deploy.go
+++ b/cmd/nic/deploy.go
@@ -61,7 +61,6 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		timeout, err = time.ParseDuration(deployTimeout)
 		if err != nil {
 			span.RecordError(err)
-			slog.Error("Invalid timeout duration", "error", err, "timeout", deployTimeout)
 			return fmt.Errorf("invalid timeout duration %q: %w", deployTimeout, err)
 		}
 		span.SetAttributes(attribute.String("timeout", deployTimeout))
@@ -70,14 +69,12 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	cfg, err := config.ParseConfig(ctx, configFile)
 	if err != nil {
 		span.RecordError(err)
-		slog.Error("Failed to parse configuration", "error", err, "file", configFile)
 		return err
 	}
 
 	client, err := nic.NewClient(ctx)
 	if err != nil {
 		span.RecordError(err)
-		slog.Error("Failed to create NIC client", "error", err)
 		return err
 	}
 

--- a/cmd/nic/destroy.go
+++ b/cmd/nic/destroy.go
@@ -70,7 +70,6 @@ func runDestroy(cmd *cobra.Command, args []string) error {
 		timeout, err = time.ParseDuration(destroyTimeout)
 		if err != nil {
 			span.RecordError(err)
-			slog.Error("Invalid timeout duration", "error", err, "timeout", destroyTimeout)
 			return fmt.Errorf("invalid timeout duration %q: %w", destroyTimeout, err)
 		}
 		span.SetAttributes(attribute.String("timeout", destroyTimeout))
@@ -79,14 +78,12 @@ func runDestroy(cmd *cobra.Command, args []string) error {
 	cfg, err := config.ParseConfig(ctx, configFile)
 	if err != nil {
 		span.RecordError(err)
-		slog.Error("Failed to parse configuration", "error", err, "file", configFile)
 		return err
 	}
 
 	client, err := nic.NewClient(ctx)
 	if err != nil {
 		span.RecordError(err)
-		slog.Error("Failed to create NIC client", "error", err)
 		return err
 	}
 

--- a/cmd/nic/kubeconfig.go
+++ b/cmd/nic/kubeconfig.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 
@@ -49,14 +50,12 @@ func runKubeconfig(cmd *cobra.Command, args []string) error {
 	cfg, err := config.ParseConfig(ctx, configFile)
 	if err != nil {
 		span.RecordError(err)
-		slog.Error("Failed to parse configuration", "error", err, "file", configFile)
 		return err
 	}
 
 	client, err := nic.NewClient(ctx)
 	if err != nil {
 		span.RecordError(err)
-		slog.Error("Failed to create NIC client", "error", err)
 		return err
 	}
 
@@ -72,8 +71,7 @@ func runKubeconfig(cmd *cobra.Command, args []string) error {
 	if kubeconfigOutputFile != "" {
 		if err := os.WriteFile(kubeconfigOutputFile, kubeconfigBytes, 0600); err != nil {
 			span.RecordError(err)
-			slog.Error("Failed to write kubeconfig file", "error", err, "file", kubeconfigOutputFile)
-			return err
+			return fmt.Errorf("write kubeconfig file %q: %w", kubeconfigOutputFile, err)
 		}
 		slog.Info("Kubeconfig written successfully", "file", kubeconfigOutputFile)
 		return nil
@@ -81,8 +79,7 @@ func runKubeconfig(cmd *cobra.Command, args []string) error {
 
 	if _, err := os.Stdout.Write(kubeconfigBytes); err != nil {
 		span.RecordError(err)
-		slog.Error("Failed to write kubeconfig to stdout", "error", err)
-		return err
+		return fmt.Errorf("write kubeconfig to stdout: %w", err)
 	}
 	return nil
 }

--- a/cmd/nic/main.go
+++ b/cmd/nic/main.go
@@ -18,6 +18,12 @@ var rootCmd = &cobra.Command{
 	Short: "Nebari Infrastructure Core - Cloud infrastructure management for Nebari",
 	Long: `Nebari Infrastructure Core (NIC) is a standalone CLI tool that manages
 cloud infrastructure for Nebari using native cloud SDKs with declarative semantics.`,
+	// Runtime failures are reported once, by main() via slog. Silence cobra's
+	// own error print and usage block so a runtime error is neither duplicated
+	// nor mistaken for misuse of the command. Cobra still prints usage for
+	// genuine argument/flag errors, which it detects before RunE runs.
+	SilenceErrors: true,
+	SilenceUsage:  true,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
 			Level: slog.LevelInfo,

--- a/cmd/nic/main.go
+++ b/cmd/nic/main.go
@@ -13,6 +13,13 @@ import (
 	"github.com/nebari-dev/nebari-infrastructure-core/pkg/telemetry"
 )
 
+// reachedRunE reports whether cobra parsed flags and validated args
+// successfully, i.e. PersistentPreRun ran and a command's RunE is about to (or
+// did) execute. main() uses it to distinguish runtime failures (which we log)
+// from usage-class errors (bad flag, unknown command, wrong number of args),
+// which surface before PersistentPreRun and are already printed by cobra.
+var reachedRunE bool
+
 var rootCmd = &cobra.Command{
 	Use:   "nic",
 	Short: "Nebari Infrastructure Core - Cloud infrastructure management for Nebari",
@@ -32,6 +39,7 @@ cloud infrastructure for Nebari using native cloud SDKs with declarative semanti
 		// the error and usage block for those.
 		cmd.SilenceErrors = true
 		cmd.SilenceUsage = true
+		reachedRunE = true
 	},
 }
 
@@ -72,17 +80,15 @@ func main() {
 		}
 	}()
 
-	cmd, err := rootCmd.ExecuteContextC(ctx)
-	if err != nil {
+	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		if ctx.Err() == context.Canceled {
 			slog.Info("Shutdown complete")
 			os.Exit(130)
 		}
-		// SilenceUsage is set in PersistentPreRun, so it is true only once RunE
-		// is reached. We log just those runtime failures and leave usage-class
-		// errors (bad flag, unknown command, bad args) to cobra, which already
-		// printed them.
-		if cmd != nil && cmd.SilenceUsage {
+		// Log only runtime failures (those that occur once RunE is reached) and
+		// leave usage-class errors (bad flag, unknown command, bad args) to
+		// cobra, which already printed them.
+		if reachedRunE {
 			slog.Error("Command execution failed", "error", err)
 		}
 		os.Exit(1)

--- a/cmd/nic/main.go
+++ b/cmd/nic/main.go
@@ -18,17 +18,20 @@ var rootCmd = &cobra.Command{
 	Short: "Nebari Infrastructure Core - Cloud infrastructure management for Nebari",
 	Long: `Nebari Infrastructure Core (NIC) is a standalone CLI tool that manages
 cloud infrastructure for Nebari using native cloud SDKs with declarative semantics.`,
-	// Runtime failures are reported once, by main() via slog. Silence cobra's
-	// own error print and usage block so a runtime error is neither duplicated
-	// nor mistaken for misuse of the command. Cobra still prints usage for
-	// genuine argument/flag errors, which it detects before RunE runs.
-	SilenceErrors: true,
-	SilenceUsage:  true,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
 			Level: slog.LevelInfo,
 		}))
 		slog.SetDefault(logger)
+
+		// PersistentPreRun runs only after cobra has parsed flags and validated
+		// args. Any failure from here on is a runtime error and not a misuse,
+		// so silence cobra's own error/usage output and let main() report it
+		// once via slog. Usage-class errors (bad flag, unknown command, wrong
+		// number of args) surface before this hook runs, so cobra still prints
+		// the error and usage block for those.
+		cmd.SilenceErrors = true
+		cmd.SilenceUsage = true
 	},
 }
 
@@ -69,12 +72,19 @@ func main() {
 		}
 	}()
 
-	if err := rootCmd.ExecuteContext(ctx); err != nil {
+	cmd, err := rootCmd.ExecuteContextC(ctx)
+	if err != nil {
 		if ctx.Err() == context.Canceled {
 			slog.Info("Shutdown complete")
 			os.Exit(130)
 		}
-		slog.Error("Command execution failed", "error", err)
+		// SilenceUsage is set in PersistentPreRun, so it is true only once RunE
+		// is reached. We log just those runtime failures and leave usage-class
+		// errors (bad flag, unknown command, bad args) to cobra, which already
+		// printed them.
+		if cmd != nil && cmd.SilenceUsage {
+			slog.Error("Command execution failed", "error", err)
+		}
 		os.Exit(1)
 	}
 }

--- a/cmd/nic/validate.go
+++ b/cmd/nic/validate.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log/slog"
 
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel"
@@ -46,19 +45,16 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	cfg, err := config.ParseConfig(ctx, configFile)
 	if err != nil {
 		span.RecordError(err)
-		slog.Error("Configuration validation failed", "error", err, "file", configFile)
 		return err
 	}
 
 	client, err := nic.NewClient(ctx)
 	if err != nil {
 		span.RecordError(err)
-		slog.Error("Failed to create NIC client", "error", err)
 		return err
 	}
 	if err := client.Validate(ctx, cfg); err != nil {
 		span.RecordError(err)
-		slog.Error("Configuration validation failed", "error", err, "file", configFile)
 		return err
 	}
 


### PR DESCRIPTION
## Closes

Closes #326 

## Description

This PR does two things:

- Pass `SilenceErrors: true` and `SilenceUsage:  true` to Cobra so errors are not duplicated and usage is not shown on failure. A wrong call to the CLI (e.g., wrong flags being passed) will still raise a usage message, which is the expected behavior.
- Remove `slog.Error` calls across different commands, as those are already being logged from main and it only resulted in the triplication of errors.



## How to Test

1. Create a malformed configuration file that will make the CLI raise an error when ran:
    ```bash
    echo 'project_name: "unterminated' > /tmp/bad.yaml
    ```

2. Before building off this branch, run the following to verify the old behavior:
    ```bash
    ./nic validate -f /tmp/bad.yaml
    ```
   
   The output will look something like this:
    ```
    {"time":"2026-06-09T18:37:05.507513+02:00","level":"ERROR","msg":"Configuration validation failed","error":"config file /tmp/bad.yaml: failed to parse YAML: [1:15] could not find end character of double-quoted text\n>  1 | project_name: \"unterminated\n                     ^\n","file":"/tmp/bad.yaml"}
    Error: config file /tmp/bad.yaml: failed to parse YAML: [1:15] could not find end character of double-quoted text
    >  1 | project_name: "unterminated
                         ^
    
    Usage:
      nic validate [flags]
    
    Flags:
      -f, --file string   Path to nebari-config.yaml file (auto-discovered if omitted)
      -h, --help          help for validate
    
    {"time":"2026-06-09T18:37:05.50755+02:00","level":"ERROR","msg":"Command execution failed","error":"config file /tmp/bad.yaml: failed to parse YAML: [1:15] could not find end character of double-quoted text\n>  1 | project_name: \"unterminated\n                     ^\n"}
    ```

    As you can see, the same error is being logged three times. One is the original error, another is the duplicate `slog.Error` inside `validate.go` and the third one comes from cobra surfacing the original error as plain text. Furthermore, usage is printed, even though it is completely irrelevant here.

3. Build off this branch, and re-run the same command:
    
    ```bash
    ./nic validate -f /tmp/bad.yaml
    ```

    The output will now look as it is supposed to, showing only one error and no usage:
    ```
    {"time":"2026-06-09T18:52:21.353657+02:00","level":"ERROR","msg":"Command execution failed","error":"config file /tmp/bad.yaml: failed to parse YAML: [1:15] could not find end character of double-quoted text\n>  1 | project_name: \"unterminated\n                     ^\n"}
    ```


