### PR TITLE
feat(certificate): add dns01 ACME challenge for private networks

### DIFF
--- a/examples/aws-config-with-dns.yaml
+++ b/examples/aws-config-with-dns.yaml
@@ -6,6 +6,13 @@ certificate:
   type: letsencrypt
   acme:
     email: admin@example.com
+    # challenge selects how Let's Encrypt validates domain ownership:
+    #   http01 (default) - ACME server connects to the cluster's gateway;
+    #                      requires the cluster to be reachable from the internet
+    #   dns01            - validation via DNS TXT records; works for private/VPN
+    #                      clusters and requires the dns block below (cert-manager
+    #                      uses the same CLOUDFLARE_API_TOKEN credential)
+    # challenge: dns01
 
 # GitOps repository configuration (required for foundational services)
 # ArgoCD uses this repository to deploy Envoy Gateway, cert-manager, Keycloak, etc.

--- a/pkg/argocd/foundational.go
+++ b/pkg/argocd/foundational.go
@@ -3,6 +3,7 @@ package argocd
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -32,6 +33,14 @@ const (
 
 	// NebariFoundationalPartOf is the value of the app.kubernetes.io/part-of label for foundational resources.
 	NebariFoundationalPartOf = "nebari-foundational"
+
+	// CertManagerNamespace is the namespace where cert-manager is deployed.
+	CertManagerNamespace = "cert-manager"
+
+	// DNS01TokenSecretName/Key identify the Cloudflare API token secret referenced
+	// by the letsencrypt ClusterIssuer's dns01 solver (apiTokenSecretRef).
+	DNS01TokenSecretName = "cloudflare-api-token" //nolint:gosec // This is a secret name reference, not a credential
+	DNS01TokenSecretKey  = "api-token"
 )
 
 // FoundationalConfig holds configuration for foundational services
@@ -153,6 +162,21 @@ func InstallFoundationalServices(ctx context.Context, cfg *config.NebariConfig, 
 		}
 	}
 
+	// Create the dns01 solver credential secret when the dns01 ACME challenge
+	// is configured, before the root App-of-Apps syncs the letsencrypt
+	// ClusterIssuer that references it.
+	if cfg.Certificate.NeedsDNS01Solver() {
+		k8sClient, err := newK8sClient(kubeconfigBytes)
+		if err != nil {
+			span.RecordError(err)
+			return fmt.Errorf("failed to create Kubernetes client: %w", err)
+		}
+		if err := createDNS01SolverSecret(ctx, k8sClient); err != nil {
+			span.RecordError(err)
+			return fmt.Errorf("failed to create dns01 solver secret: %w", err)
+		}
+	}
+
 	// 3. Apply root App-of-Apps if git configuration is available
 	if gitConfig != nil {
 		if err := ApplyRootAppOfApps(ctx, kubeconfigBytes, gitConfig); err != nil {
@@ -230,6 +254,33 @@ func createSecret(ctx context.Context, client kubernetes.Interface, secret *core
 			WithMetadata("secret_name", secret.Name))
 	}
 	return nil
+}
+
+// createDNS01SolverSecret creates the Cloudflare API token secret referenced by
+// the letsencrypt ClusterIssuer's dns01 solver. The token is read from the
+// CLOUDFLARE_API_TOKEN environment variable (the same credential the DNS record
+// provisioner uses) and is created directly on the cluster, never written to
+// the GitOps repository.
+func createDNS01SolverSecret(ctx context.Context, client kubernetes.Interface) error {
+	token := os.Getenv("CLOUDFLARE_API_TOKEN")
+	if token == "" {
+		return fmt.Errorf("CLOUDFLARE_API_TOKEN environment variable is required for the dns01 ACME challenge")
+	}
+
+	if err := createNamespace(ctx, client, CertManagerNamespace); err != nil {
+		return err
+	}
+
+	return createSecret(ctx, client, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DNS01TokenSecretName,
+			Namespace: CertManagerNamespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		StringData: map[string]string{
+			DNS01TokenSecretKey: token,
+		},
+	})
 }
 
 // createKeycloakSecrets creates the required secrets for Keycloak and PostgreSQL

--- a/pkg/argocd/foundational_test.go
+++ b/pkg/argocd/foundational_test.go
@@ -2,6 +2,7 @@ package argocd
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -374,6 +375,38 @@ func TestNewK8sClient(t *testing.T) {
 		_, err := newK8sClient([]byte{})
 		if err == nil {
 			t.Error("newK8sClient() should fail with empty kubeconfig")
+		}
+	})
+}
+
+func TestCreateDNS01SolverSecret(t *testing.T) {
+	t.Run("creates namespace and secret from env token", func(t *testing.T) {
+		t.Setenv("CLOUDFLARE_API_TOKEN", "test-token")
+		client := fake.NewSimpleClientset() //nolint:staticcheck // SA1019: NewSimpleClientset is deprecated but still functional for tests
+
+		if err := createDNS01SolverSecret(context.Background(), client); err != nil {
+			t.Fatalf("createDNS01SolverSecret() error: %v", err)
+		}
+
+		secret, err := client.CoreV1().Secrets(CertManagerNamespace).Get(context.Background(), DNS01TokenSecretName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected secret to exist: %v", err)
+		}
+		if got := secret.StringData[DNS01TokenSecretKey]; got != "test-token" {
+			t.Errorf("secret %s = %q, want %q", DNS01TokenSecretKey, got, "test-token")
+		}
+	})
+
+	t.Run("fails without env token", func(t *testing.T) {
+		t.Setenv("CLOUDFLARE_API_TOKEN", "")
+		client := fake.NewSimpleClientset() //nolint:staticcheck // SA1019: NewSimpleClientset is deprecated but still functional for tests
+
+		err := createDNS01SolverSecret(context.Background(), client)
+		if err == nil {
+			t.Fatal("expected error when CLOUDFLARE_API_TOKEN is unset")
+		}
+		if !strings.Contains(err.Error(), "CLOUDFLARE_API_TOKEN") {
+			t.Errorf("error %q should mention CLOUDFLARE_API_TOKEN", err.Error())
 		}
 	})
 }

--- a/pkg/argocd/templates/manifests/security/issuers/letsencrypt-clusterissuer.yaml
+++ b/pkg/argocd/templates/manifests/security/issuers/letsencrypt-clusterissuer.yaml
@@ -12,9 +12,17 @@ spec:
     privateKeySecretRef:
       name: letsencrypt-account-key
     solvers:
+{{- if eq .ACMEChallenge "dns01" }}
+      - dns01:
+          cloudflare:
+            apiTokenSecretRef:
+              name: cloudflare-api-token
+              key: api-token
+{{- else }}
       - http01:
           gatewayHTTPRoute:
             parentRefs:
               - name: nebari-gateway
                 namespace: envoy-gateway-system
                 kind: Gateway
+{{- end }}

--- a/pkg/argocd/writer.go
+++ b/pkg/argocd/writer.go
@@ -48,6 +48,7 @@ type TemplateData struct {
 	CertificateIssuer string // "selfsigned-issuer" or "letsencrypt-issuer"
 	ACMEEmail         string
 	ACMEServer        string
+	ACMEChallenge     string // "http01" or "dns01" — selects the letsencrypt ClusterIssuer solver
 
 	// MetalLB configuration (for local provider)
 	MetalLBAddressRange string
@@ -110,11 +111,15 @@ func NewTemplateData(cfg *config.NebariConfig, gitConfig *git.Config, settings p
 	if cfg.Certificate != nil {
 		if cfg.Certificate.Type == "letsencrypt" {
 			data.CertificateIssuer = "letsencrypt-issuer"
+			data.ACMEChallenge = config.ACMEChallengeHTTP01
 			if cfg.Certificate.ACME != nil {
 				data.ACMEEmail = cfg.Certificate.ACME.Email
 				data.ACMEServer = cfg.Certificate.ACME.Server
 				if data.ACMEServer == "" {
 					data.ACMEServer = "https://acme-v02.api.letsencrypt.org/directory"
+				}
+				if cfg.Certificate.ACME.Challenge != "" {
+					data.ACMEChallenge = cfg.Certificate.ACME.Challenge
 				}
 			}
 		} else {

--- a/pkg/argocd/writer_test.go
+++ b/pkg/argocd/writer_test.go
@@ -739,3 +739,94 @@ func TestEnvoyGatewayBeforeCertManager(t *testing.T) {
 		t.Errorf("envoy-gateway (%d) must have a lower sync-wave than cert-manager (%d)", envoyWaveNum, certWaveNum)
 	}
 }
+
+func TestNewTemplateData_ACMEChallenge(t *testing.T) {
+	tests := []struct {
+		name          string
+		cert          *config.CertificateConfig
+		wantChallenge string
+	}{
+		{
+			name:          "selfsigned has no challenge",
+			cert:          &config.CertificateConfig{Type: "selfsigned"},
+			wantChallenge: "",
+		},
+		{
+			name:          "letsencrypt defaults to http01",
+			cert:          &config.CertificateConfig{Type: "letsencrypt", ACME: &config.ACMEConfig{Email: "a@example.com"}},
+			wantChallenge: config.ACMEChallengeHTTP01,
+		},
+		{
+			name:          "letsencrypt without acme block defaults to http01",
+			cert:          &config.CertificateConfig{Type: "letsencrypt"},
+			wantChallenge: config.ACMEChallengeHTTP01,
+		},
+		{
+			name:          "letsencrypt with dns01",
+			cert:          &config.CertificateConfig{Type: "letsencrypt", ACME: &config.ACMEConfig{Email: "a@example.com", Challenge: config.ACMEChallengeDNS01}},
+			wantChallenge: config.ACMEChallengeDNS01,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.NebariConfig{Domain: "test.example.com", Certificate: tt.cert}
+			data := NewTemplateData(cfg, nil, provider.InfraSettings{})
+			if data.ACMEChallenge != tt.wantChallenge {
+				t.Errorf("ACMEChallenge = %q, want %q", data.ACMEChallenge, tt.wantChallenge)
+			}
+		})
+	}
+}
+
+func TestLetsEncryptClusterIssuerTemplate_Solvers(t *testing.T) {
+	render := func(t *testing.T, challenge string) string {
+		t.Helper()
+		data := TemplateData{
+			ACMEEmail:     "a@example.com",
+			ACMEServer:    "https://acme-v02.api.letsencrypt.org/directory",
+			ACMEChallenge: challenge,
+		}
+		content, err := templates.ReadFile("templates/manifests/security/issuers/letsencrypt-clusterissuer.yaml")
+		if err != nil {
+			t.Fatalf("failed to read issuer template: %v", err)
+		}
+		processed, err := processTemplate("manifests/security/issuers/letsencrypt-clusterissuer.yaml", content, data)
+		if err != nil {
+			t.Fatalf("processTemplate() error: %v", err)
+		}
+		return string(processed)
+	}
+
+	t.Run("http01 default", func(t *testing.T) {
+		output := render(t, config.ACMEChallengeHTTP01)
+		if !strings.Contains(output, "http01:") {
+			t.Errorf("expected http01 solver, got:\n%s", output)
+		}
+		if !strings.Contains(output, "gatewayHTTPRoute:") {
+			t.Errorf("expected gatewayHTTPRoute solver config, got:\n%s", output)
+		}
+		if strings.Contains(output, "dns01:") {
+			t.Errorf("should NOT contain dns01 solver, got:\n%s", output)
+		}
+	})
+
+	t.Run("dns01 cloudflare", func(t *testing.T) {
+		output := render(t, config.ACMEChallengeDNS01)
+		if !strings.Contains(output, "dns01:") {
+			t.Errorf("expected dns01 solver, got:\n%s", output)
+		}
+		if !strings.Contains(output, "cloudflare:") {
+			t.Errorf("expected cloudflare dns01 config, got:\n%s", output)
+		}
+		if !strings.Contains(output, "name: "+DNS01TokenSecretName) {
+			t.Errorf("expected apiTokenSecretRef name %q, got:\n%s", DNS01TokenSecretName, output)
+		}
+		if !strings.Contains(output, "key: "+DNS01TokenSecretKey) {
+			t.Errorf("expected apiTokenSecretRef key %q, got:\n%s", DNS01TokenSecretKey, output)
+		}
+		if strings.Contains(output, "http01:") {
+			t.Errorf("should NOT contain http01 solver, got:\n%s", output)
+		}
+	})
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -165,6 +165,12 @@ type CertificateConfig struct {
 	ACME *ACMEConfig `yaml:"acme,omitempty"`
 }
 
+// ACME challenge types.
+const (
+	ACMEChallengeHTTP01 = "http01"
+	ACMEChallengeDNS01  = "dns01"
+)
+
 // ACMEConfig holds ACME (Let's Encrypt) configuration
 type ACMEConfig struct {
 	// Email is the email address for Let's Encrypt registration
@@ -173,6 +179,38 @@ type ACMEConfig struct {
 	// Server is the ACME server URL (defaults to Let's Encrypt production)
 	// Use "https://acme-staging-v02.api.letsencrypt.org/directory" for testing
 	Server string `yaml:"server,omitempty"`
+
+	// Challenge is the ACME challenge type: "http01" (default) or "dns01".
+	// dns01 validates domain ownership via DNS TXT records instead of inbound
+	// HTTP, so it works for clusters the ACME server cannot reach (private
+	// networks, VPNs). It requires a dns provider block for solver credentials.
+	Challenge string `yaml:"challenge,omitempty"`
+}
+
+// NeedsDNS01Solver reports whether the configuration requires a cert-manager
+// dns01 solver (letsencrypt certificates with the dns01 challenge).
+func (c *CertificateConfig) NeedsDNS01Solver() bool {
+	return c != nil && c.Type == "letsencrypt" && c.ACME != nil && c.ACME.Challenge == ACMEChallengeDNS01
+}
+
+// Validate checks the certificate configuration. The dns config is consulted
+// because the dns01 challenge sources its solver credentials from the dns
+// provider.
+func (c *CertificateConfig) Validate(dns *DNSConfig) error {
+	if c.ACME == nil {
+		return nil
+	}
+	switch c.ACME.Challenge {
+	case "", ACMEChallengeHTTP01:
+		return nil
+	case ACMEChallengeDNS01:
+		if dns.ProviderName() != "cloudflare" {
+			return fmt.Errorf("acme challenge %q requires a dns block with the %q provider (the only provider with dns01 solver support)", ACMEChallengeDNS01, "cloudflare")
+		}
+		return nil
+	default:
+		return fmt.Errorf("invalid acme challenge %q, must be %q or %q", c.ACME.Challenge, ACMEChallengeHTTP01, ACMEChallengeDNS01)
+	}
 }
 
 // safeProjectName matches alphanumeric strings with hyphens and underscores.
@@ -200,6 +238,12 @@ func (c *NebariConfig) Validate(opts ValidateOptions) error {
 	if c.DNS != nil {
 		if err := c.DNS.Validate(opts.DNSProviders); err != nil {
 			return fmt.Errorf("invalid dns: %w", err)
+		}
+	}
+
+	if c.Certificate != nil {
+		if err := c.Certificate.Validate(c.DNS); err != nil {
+			return fmt.Errorf("invalid certificate: %w", err)
 		}
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -838,3 +838,89 @@ func TestUnmarshalProviderConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestCertificateConfigValidate(t *testing.T) {
+	cloudflareDNS := &DNSConfig{
+		Providers: map[string]any{"cloudflare": map[string]any{"zone_name": "example.com"}},
+	}
+
+	tests := []struct {
+		name        string
+		cert        CertificateConfig
+		dns         *DNSConfig
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "selfsigned without acme is valid",
+			cert: CertificateConfig{Type: "selfsigned"},
+		},
+		{
+			name: "letsencrypt with default challenge is valid",
+			cert: CertificateConfig{Type: "letsencrypt", ACME: &ACMEConfig{Email: "a@example.com"}},
+		},
+		{
+			name: "explicit http01 is valid without dns",
+			cert: CertificateConfig{Type: "letsencrypt", ACME: &ACMEConfig{Email: "a@example.com", Challenge: ACMEChallengeHTTP01}},
+		},
+		{
+			name: "dns01 with cloudflare dns is valid",
+			cert: CertificateConfig{Type: "letsencrypt", ACME: &ACMEConfig{Email: "a@example.com", Challenge: ACMEChallengeDNS01}},
+			dns:  cloudflareDNS,
+		},
+		{
+			name:        "dns01 without dns block is rejected",
+			cert:        CertificateConfig{Type: "letsencrypt", ACME: &ACMEConfig{Email: "a@example.com", Challenge: ACMEChallengeDNS01}},
+			wantErr:     true,
+			errContains: "requires a dns block",
+		},
+		{
+			name:        "unknown challenge is rejected",
+			cert:        CertificateConfig{Type: "letsencrypt", ACME: &ACMEConfig{Email: "a@example.com", Challenge: "tls-alpn-01"}},
+			wantErr:     true,
+			errContains: "invalid acme challenge",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cert.Validate(tt.dns)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestCertificateConfigNeedsDNS01Solver(t *testing.T) {
+	dns01ACME := &ACMEConfig{Email: "a@example.com", Challenge: ACMEChallengeDNS01}
+
+	tests := []struct {
+		name string
+		cert *CertificateConfig
+		want bool
+	}{
+		{"nil receiver", nil, false},
+		{"selfsigned", &CertificateConfig{Type: "selfsigned"}, false},
+		{"letsencrypt default challenge", &CertificateConfig{Type: "letsencrypt", ACME: &ACMEConfig{Email: "a@example.com"}}, false},
+		{"letsencrypt dns01", &CertificateConfig{Type: "letsencrypt", ACME: dns01ACME}, true},
+		{"selfsigned with dns01 acme is ignored", &CertificateConfig{Type: "selfsigned", ACME: dns01ACME}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cert.NeedsDNS01Solver(); got != tt.want {
+				t.Errorf("NeedsDNS01Solver() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `certificate.acme.challenge` config field (`http01` default, `dns01`) so Let's Encrypt certificates can be issued for clusters the ACME server cannot reach — private IPs, VPN-only deployments. DNS-01 validates ownership via DNS TXT records instead of inbound HTTP.
- When `dns01` is selected, the `letsencrypt-issuer` ClusterIssuer renders a Cloudflare `dns01` solver (`apiTokenSecretRef` → `cloudflare-api-token`/`api-token`), and the foundational bootstrap creates that Secret in the `cert-manager` namespace from `CLOUDFLARE_API_TOKEN` (the same credential the DNS record provisioner uses) before the root App-of-Apps syncs the issuer. The token is never written to the GitOps repository.
- Config validation requires a `dns:` block with the `cloudflare` provider when `dns01` is chosen, and rejects unknown challenge values. The default `http01` path renders byte-identical to before.

Cloudflare is the only solver wired up since it is the only DNS provider in tree; additional hosts (route53, azure-dns) can be added behind the same `challenge` field later.

Refs https://github.com/nebari-dev/nebari-infrastructure-core/issues/71

## Test plan

- [x] `go test -short ./...` passes
- [x] Unit tests: challenge validation (valid/invalid/missing dns block), `NeedsDNS01Solver`, ClusterIssuer template rendering for both solvers, template-data plumbing, solver Secret creation (fake clientset, including missing-env error)
- [x] `golangci-lint run` — 0 issues
- [ ] End-to-end: deploy with `challenge: dns01` on a private-network cluster and confirm cert issuance (planned on the nrec test rig)