### PR TITLE
fix(argocd): match both bare and full-path group names in RBAC policy

### DIFF
--- a/pkg/argocd/config.go
+++ b/pkg/argocd/config.go
@@ -55,8 +55,16 @@ requestedScopes:
   - email
   - groups`, issuerURL)
 
+	// Group names are matched both with and without a leading slash because the
+	// Keycloak group-membership mapper's full.path setting differs by deployment
+	// phase: the realm-setup job creates it with full.path=false ("argocd-admins"),
+	// but the data-science-pack rbac-bootstrap job reconciles it to full.path=true
+	// ("/argocd-admins") on every sync, which JupyterHub requires for shared-dir
+	// mounts. Matching both keeps ArgoCD access working regardless of which ran last.
 	rbacPolicy := `g, argocd-admins, role:admin
-g, argocd-viewers, role:readonly`
+g, /argocd-admins, role:admin
+g, argocd-viewers, role:readonly
+g, /argocd-viewers, role:readonly`
 
 	configs := cfg.Values["configs"].(map[string]any)
 	configs["cm"] = map[string]any{

--- a/pkg/argocd/config_test.go
+++ b/pkg/argocd/config_test.go
@@ -132,11 +132,19 @@ func TestConfigWithOIDC(t *testing.T) {
 			if !ok {
 				t.Fatal("rbac.policy.csv should be a string")
 			}
-			if !strings.Contains(policyCSV, "g, argocd-admins, role:admin") {
-				t.Error("policy.csv should map argocd-admins to role:admin")
-			}
-			if !strings.Contains(policyCSV, "g, argocd-viewers, role:readonly") {
-				t.Error("policy.csv should map argocd-viewers to role:readonly")
+			// Both bare and full-path group names must be mapped: the Keycloak
+			// group-membership mapper's full.path setting differs depending on
+			// whether the realm-setup job (false) or the data-science-pack
+			// rbac-bootstrap job (true) ran last.
+			for _, mapping := range []string{
+				"g, argocd-admins, role:admin",
+				"g, /argocd-admins, role:admin",
+				"g, argocd-viewers, role:readonly",
+				"g, /argocd-viewers, role:readonly",
+			} {
+				if !strings.Contains(policyCSV, mapping) {
+					t.Errorf("policy.csv should contain %q", mapping)
+				}
 			}
 
 			// Check secret injection


### PR DESCRIPTION
Fixes #384

## Problem

The data-science-pack rbac-bootstrap job reconciles the Keycloak group-membership mapper to `full.path=true` on every sync (JupyterHub needs full group paths for `/shared/<group>` mounts). Tokens then carry `groups: ["/argocd-admins"]` instead of `["argocd-admins"]`, the RBAC policy installed by `ConfigWithOIDC` stops matching, and with `policy.default` empty users lose all visibility in ArgoCD. See #384 for the full investigation.

## Change

Map both the bare and slash-prefixed form of each group in `policy.csv`, so access works whether the realm-setup job (`full.path=false`) or the ds-pack bootstrap job (`full.path=true`) ran last:

```
g, argocd-admins, role:admin
g, /argocd-admins, role:admin
g, argocd-viewers, role:readonly
g, /argocd-viewers, role:readonly
```

ArgoCD's casbin `g` subject matching is exact, so the extra entries cannot over-match; whichever form is absent from the token is simply unused.

## Testing

- `go test -short ./...` passes
- `go vet ./...` and `gofmt` clean
- Verified on the mystic.openteams.ai cluster: patching `argocd-rbac-cm` with these four lines restored app visibility for a user in `argocd-admins` with the mapper at `full.path=true`

## Note for existing installations

Per the comment on the `Config` struct, upgrade-skip logic only compares chart versions, so this Values-only change will not reach already-bootstrapped clusters on its own. Existing clusters need either a chart version bump or a manual patch of `argocd-rbac-cm` (the mystic cluster is already patched).