### PR TITLE
add k8s preset to otel collector

### DIFF
--- a/pkg/argocd/templates/apps/opentelemetry-collector.yaml
+++ b/pkg/argocd/templates/apps/opentelemetry-collector.yaml
@@ -24,6 +24,9 @@ spec:
           repository: otel/opentelemetry-collector-k8s
           tag: ""
         mode: daemonset
+        presets:
+          kubernetesAttributes:
+            enabled: true
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
## Description

When testing the [LGTM pack]() I noticed the following error in the OTEL collector logs:

```
E0612 21:09:54.798119       1 reflector.go:205] "Failed to watch" err="failed to list *v1.Pod: pods is forbidden: User \"system:serviceaccount:monitoring:opentelemetry-collector\" cannot list
 resource \"pods\" in API group \"\" at the cluster scope" logger="UnhandledError" reflector="k8s.io/client-go@v0.34.3/tools/cache/reflector.go:290" type="*v1.Pod"
```

So part of its job is to scrape the cluster for metrics, but without permissions it cannot do so.

To solve this we could manually create a ClusterRole with the right permissions, but the OTEL collector chart provides a better option: enabling the [k8s attributes preset](https://opentelemetry.io/docs/platforms/kubernetes/helm/collector/#kubernetes-attributes-preset)

> The OpenTelemetry Collector can be configured to collect node, pod, and container metrics from the API server on a kubelet.
> [...]
> When enabled, the chart will add the necessary RBAC roles to the ClusterRole [...]

## How to Test

Deploy and look at the container logs of the OTEL collector to verify the error is gone.
