### PR TITLE
enable service for OTEL collector

### DIFF
--- a/pkg/argocd/templates/apps/opentelemetry-collector.yaml
+++ b/pkg/argocd/templates/apps/opentelemetry-collector.yaml
@@ -34,6 +34,8 @@ spec:
           limits:
             cpu: 500m
             memory: 512Mi
+        service:
+          enabled: true
         config:
           receivers:
             otlp:


### PR DESCRIPTION
## Description

We need a service for the OTEL collector to reliably connect to it from producer charts. [However](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/6f45815a231577e53c40a4dd57aeffddad632c70/charts/opentelemetry-collector/values.yaml#L617-L621)

```yaml
service:
  # Enable the creation of a Service.
  # By default, it's enabled on mode != daemonset.
  # However, to enable it on mode = daemonset, its creation must be explicitly enabled
  # enabled: true
```

and we have

https://github.com/nebari-dev/nebari-infrastructure-core/blob/870311caf664e3b7effd409a9d5a266d1aef761d/pkg/argocd/templates/apps/opentelemetry-collector.yaml#L26

## How to Test

Deploy and see if a service is created for the OTEL collector.
