### PR TITLE
fix(otel): opt monitoring ns into Nebari management + escape kubernetes-pods relabel

### DIFF
--- a/pkg/argocd/templates/apps/opentelemetry-collector.yaml
+++ b/pkg/argocd/templates/apps/opentelemetry-collector.yaml
@@ -241,6 +241,16 @@ spec:
     namespace: monitoring
 
   syncPolicy:
+    # Opt the monitoring namespace into Nebari management at creation time.
+    # The collector app (sync-wave 4) is the first thing to create this
+    # namespace, so any later software pack that drops a NebariApp here
+    # (e.g. nebari-lgtm-pack exposing Grafana via the gateway) is reconciled
+    # by the nebari-operator instead of rejected with NamespaceNotOptedIn.
+    # managedNamespaceMetadata only applies the label to a namespace this app
+    # creates, hence it must live on the namespace's creator, not the pack.
+    managedNamespaceMetadata:
+      labels:
+        nebari.dev/managed: "true"
     automated:
       prune: true
       selfHeal: true

--- a/pkg/argocd/templates/apps/opentelemetry-collector.yaml
+++ b/pkg/argocd/templates/apps/opentelemetry-collector.yaml
@@ -88,7 +88,13 @@ spec:
                       - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
                         action: replace
                         regex: ([^:]+)(?::\d+)?;(\d+)
-                        replacement: $1:$2
+                        # $$ escapes the $ for the OTel collector's confmap
+                        # resolver (which expands ${...}); it resolves to a
+                        # literal $1/$2 Prometheus regex backreference. Bare
+                        # $1:$2 is the deprecated form and triggers env-style
+                        # expansion warnings. Matches the $${1} used by the
+                        # cAdvisor/kubelet jobs below.
+                        replacement: $$1:$$2
                         target_label: __address__
 
                   # cAdvisor — per-container CPU/memory/network metrics

--- a/pkg/argocd/writer_test.go
+++ b/pkg/argocd/writer_test.go
@@ -771,6 +771,11 @@ func TestWriteApplication_OtelCollector_OverridesExtensionPoint(t *testing.T) {
 		// kubernetes-pods relabel uses the escaped $$1:$$2 backreference so the
 		// OTel collector confmap resolver doesn't treat it as env expansion.
 		{"escaped relabel replacement", "replacement: $$1:$$2", true},
+		// Opts the monitoring namespace into Nebari management at creation so
+		// software packs (e.g. nebari-lgtm-pack) can drop a NebariApp here and
+		// have the nebari-operator reconcile it instead of rejecting it.
+		{"managedNamespaceMetadata block", "managedNamespaceMetadata:", true},
+		{"nebari.dev/managed namespace label", "nebari.dev/managed: \"true\"", true},
 		// Forbidden fragments — old ignoreDifferences design + deprecated bare backref
 		{"bare relabel replacement (deprecated)", "replacement: $1:$2", false},
 		{"ignoreDifferences (old design)", "ignoreDifferences:", false},

--- a/pkg/argocd/writer_test.go
+++ b/pkg/argocd/writer_test.go
@@ -768,7 +768,11 @@ func TestWriteApplication_OtelCollector_OverridesExtensionPoint(t *testing.T) {
 		{"initContainers section", "initContainers:", true},
 		{"ensure-overrides init container", "name: ensure-overrides", true},
 		{"config flag for overrides", "--config=/conf/overrides/relay.yaml", true},
-		// Forbidden fragments — old ignoreDifferences design
+		// kubernetes-pods relabel uses the escaped $$1:$$2 backreference so the
+		// OTel collector confmap resolver doesn't treat it as env expansion.
+		{"escaped relabel replacement", "replacement: $$1:$$2", true},
+		// Forbidden fragments — old ignoreDifferences design + deprecated bare backref
+		{"bare relabel replacement (deprecated)", "replacement: $1:$2", false},
 		{"ignoreDifferences (old design)", "ignoreDifferences:", false},
 		{"RespectIgnoreDifferences (old design)", "RespectIgnoreDifferences=true", false},
 		{"jsonPointers (old design)", "jsonPointers:", false},


### PR DESCRIPTION
## Summary

Two follow-ups to https://github.com/nebari-dev/nebari-infrastructure-core/pull/331, both supporting the now-released [nebari-lgtm-pack](https://github.com/nebari-dev/nebari-lgtm-pack) `0.1.1`:

1. **Opt the `monitoring` namespace into Nebari management.** The `opentelemetry-collector` app (sync-wave 4) is the first thing to create the `monitoring` namespace, so it now stamps `nebari.dev/managed: "true"` via `managedNamespaceMetadata`. Without this, a software pack that deploys a `NebariApp` into `monitoring` (e.g. the LGTM pack exposing Grafana through the gateway) is rejected by the nebari-operator with `NamespaceNotOptedIn` — so Grafana never gets its OAuth client/secret. A pack can't set this label itself, because `managedNamespaceMetadata` only applies to a namespace the app *creates*, and the collector creates it first.

2. **Escape the `kubernetes-pods` relabel replacement** from the bare `$1:$2` to `$$1:$$2`. The OTel collector's confmap resolver expands `${...}`, so a bare `$1` is the deprecated env-style form; `$$` resolves to a literal `$` for the Prometheus regex backreference. This matches the `$${1}` already used by the cAdvisor/kubelet jobs. Resolves the deferred review item from https://github.com/nebari-dev/nebari-infrastructure-core/pull/331#discussion_r3341866431.

## Test plan

Both changes validated on a local kind cluster:

- [x] **monitoring opt-in**: `monitoring` namespace carries `nebari.dev/managed=true`; the LGTM pack's `NebariApp` reconciles (`Ready=True`), the operator provisions the Grafana OAuth client/secret, and Grafana login succeeds.
- [x] **relabel escaping**: collector ConfigMap renders `replacement: $$1:$$2`, DaemonSet rolls cleanly, and `up{job="kubernetes-pods"}` returns the identical 7 targets (`up=1`) with the same `podIP:port` addresses as before — confirming behavioral parity.
- [x] `go test ./pkg/argocd/` + `golangci-lint run` green; writer-test assertions added pinning both the escaped replacement and the managed-namespace label.