### PR TITLE
feat(certificate): support user-supplied TLS cert for the gateway

### DIFF
--- a/docs/custom-tls-certificate.md
+++ b/docs/custom-tls-certificate.md
@@ -1,0 +1,177 @@
+# Custom TLS Certificate for the Nebari Gateway
+
+By default, NIC has [cert-manager](https://cert-manager.io/) mint the TLS
+certificate for the Nebari gateway, using either a self-signed or Let's Encrypt
+`ClusterIssuer`. If you already manage certificates yourself (a corporate CA, a
+wildcard cert, an external ACME setup, etc.), you can supply your own certificate
+instead with `certificate.type: existing`.
+
+## How TLS termination works
+
+Nebari fronts all in-cluster HTTPS traffic with a single Envoy Gateway in the
+`envoy-gateway-system` namespace. That one gateway terminates TLS for **every**
+hostname under your configured `domain`, so a single certificate must cover all
+of them.
+
+## SAN requirements
+
+The certificate must include Subject Alternative Names (SANs) for:
+
+- `<domain>` — e.g. `nebari.example.com`
+- `keycloak.<domain>` — e.g. `keycloak.nebari.example.com`
+- `argocd.<domain>` — e.g. `argocd.nebari.example.com`
+
+A wildcard plus the apex also works: `*.nebari.example.com` **and**
+`nebari.example.com` (a wildcard alone does not match the bare apex).
+
+> NIC parses the certificate and **warns** — it does not fail — when one of these
+> hostnames is missing. This is intentional: many valid setups carry additional
+> hostnames NIC doesn't know about, and hard-failing would block them. If you see
+> a SAN warning, double-check the served hostnames before going to production.
+
+## The three sources
+
+Set `certificate.type: existing` and provide **exactly one** of the following
+sources. `secret_name` is optional and defaults to `nebari-gateway-tls`.
+
+### 1. `existing_secret` — reference a secret you already created
+
+Use this when you (or another controller, e.g. a `Certificate` you manage, an
+external-secrets sync, etc.) already maintain a `kubernetes.io/tls` secret in the
+cluster.
+
+```yaml
+certificate:
+  type: existing
+  existing_secret:
+    name: my-gateway-tls
+    # namespace defaults to envoy-gateway-system
+```
+
+Create the secret with `kubectl`:
+
+```bash
+kubectl create secret tls my-gateway-tls \
+  --cert=tls.crt \
+  --key=tls.key \
+  --namespace envoy-gateway-system
+```
+
+NIC does **not** create or overwrite this secret; it only reads it to run the SAN
+check. Make sure it exists before traffic is served.
+
+### 2. `files` — read PEM material from disk
+
+NIC reads the PEM files at deploy time and creates the `kubernetes.io/tls` secret
+directly in `envoy-gateway-system`.
+
+```yaml
+certificate:
+  type: existing
+  files:
+    cert_file: /path/to/tls.crt
+    key_file: /path/to/tls.key
+```
+
+The cert/key are written **only** to the cluster secret — they are never committed
+to the GitOps repository.
+
+### 3. `env` — read PEM material from environment variables
+
+The variables hold **raw PEM** (not base64-encoded). NIC reads them at deploy
+time and creates the secret directly.
+
+```yaml
+certificate:
+  type: existing
+  env:
+    cert_env: NEBARI_TLS_CERT
+    key_env: NEBARI_TLS_KEY
+```
+
+```bash
+export NEBARI_TLS_CERT="$(cat tls.crt)"
+export NEBARI_TLS_KEY="$(cat tls.key)"
+nic deploy -c config.yaml
+```
+
+As with `files`, the material is never persisted to the GitOps repository.
+
+## Cross-namespace secrets and ReferenceGrant
+
+If your `existing_secret` lives in a namespace **other than**
+`envoy-gateway-system`, the Gateway API requires explicit permission for the
+gateway to read it across namespaces. NIC handles this automatically: it sets the
+`namespace` on the gateway's `certificateRefs` and renders a
+[`ReferenceGrant`](https://gateway-api.sigs.k8s.io/api-types/referencegrant/) in
+your secret's namespace.
+
+```yaml
+certificate:
+  type: existing
+  existing_secret:
+    name: my-gateway-tls
+    namespace: my-tls-namespace
+```
+
+> **Prerequisite:** for a cross-namespace `existing_secret`, both the namespace
+> **and** the secret must already exist in the cluster before you deploy. NIC
+> does not create the namespace (it belongs to you), and Argo CD cannot apply the
+> generated `ReferenceGrant` into a namespace that doesn't exist yet.
+
+The generated `ReferenceGrant` (committed to the GitOps repo) looks like:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: nebari-gateway-tls-grant
+  namespace: my-tls-namespace
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: envoy-gateway-system
+  to:
+    - group: ""
+      kind: Secret
+      name: my-gateway-tls
+```
+
+This only applies to `existing_secret`. The `files` and `env` sources always
+create the secret in `envoy-gateway-system`, so no `ReferenceGrant` is needed.
+
+## Validation rules
+
+`nic validate` (and `nic deploy`) reject:
+
+- `type: existing` with **no** source set
+- `type: existing` with **more than one** of `existing_secret` / `files` / `env`
+- `files` or `env` with only one of the pair set (both are required)
+- `existing_secret` without a `name`
+- combining `acme` with `type: existing`
+
+## Verifying the served certificate
+
+After deploying, confirm the gateway is serving your certificate:
+
+```bash
+echo | openssl s_client -connect argocd.nebari.example.com:443 \
+  -servername argocd.nebari.example.com 2>/dev/null \
+  | openssl x509 -noout -issuer -subject -ext subjectAltName
+```
+
+Repeat for `keycloak.<domain>` and the apex `<domain>`.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| SAN warning during deploy | Cert is missing `keycloak.` / `argocd.` / apex | Reissue the cert with all required SANs (or a wildcard + apex). |
+| Browser shows the default self-signed cert | The gateway can't find the secret | Confirm the secret exists in the right namespace and matches `secret_name` / `existing_secret.name`. |
+| `existing_secret` in another namespace not served | Missing cross-namespace permission | NIC renders a `ReferenceGrant` automatically; ensure the GitOps sync applied it (check Argo CD). |
+| Deploy warning: "Failed to configure gateway TLS certificate" | Bad `files` path, empty `env` var, or mismatched cert/key | Fix the path/var, ensure the cert and key are a valid pair, redeploy. |
+| `invalid TLS certificate/key pair` | Cert and key don't match, or malformed PEM | Verify with `openssl x509 -noout -modulus -in tls.crt` vs `openssl rsa/ec -noout -modulus -in tls.key`. |
+
+See [`examples/custom-tls-config.yaml`](../examples/custom-tls-config.yaml) for a
+complete, annotated configuration.

--- a/examples/custom-tls-config.yaml
+++ b/examples/custom-tls-config.yaml
@@ -1,0 +1,59 @@
+# Example: supply your own TLS certificate for the Nebari gateway.
+#
+# Nebari fronts all in-cluster HTTPS traffic with a single Envoy Gateway that
+# terminates TLS for every hostname under `domain`. With `type: existing` you
+# provide the certificate instead of having cert-manager mint one.
+#
+# The certificate must cover the apex domain and the keycloak/argocd subdomains:
+#   - nebari.example.com
+#   - keycloak.nebari.example.com
+#   - argocd.nebari.example.com
+# A wildcard (*.nebari.example.com) plus the apex (nebari.example.com) also works.
+# NIC warns (does not fail) if a recommended SAN is missing.
+#
+# See docs/custom-tls-certificate.md for the full guide.
+
+project_name: my-nebari-custom-tls
+domain: nebari.example.com
+
+cluster:
+  aws:
+    region: us-west-2
+
+certificate:
+  type: existing
+
+  # Optional. Name of the TLS secret NIC creates for the files/env sources.
+  # Defaults to "nebari-gateway-tls". Cannot be combined with existing_secret
+  # (which references existing_secret.name directly).
+  # secret_name: nebari-gateway-tls
+
+  # Provide exactly ONE of the three sources below.
+
+  # 1. Reference a kubernetes.io/tls secret you already created in the cluster.
+  #    namespace is optional and defaults to envoy-gateway-system. When it lives
+  #    in another namespace, NIC renders a Gateway-API ReferenceGrant so the
+  #    gateway may read it.
+  existing_secret:
+    name: my-gateway-tls
+    # namespace: my-tls-namespace
+
+  # 2. Read PEM material from files on disk. NIC creates the secret directly in
+  #    envoy-gateway-system; the cert/key never enter the GitOps repo.
+  # files:
+  #   cert_file: /path/to/tls.crt
+  #   key_file: /path/to/tls.key
+
+  # 3. Read raw (non-base64) PEM material from environment variables. NIC creates
+  #    the secret directly; the cert/key never enter the GitOps repo.
+  # env:
+  #   cert_env: NEBARI_TLS_CERT
+  #   key_env: NEBARI_TLS_KEY
+
+# GitOps repository configuration (required for foundational services)
+git_repository:
+  url: "git@github.com:my-org/my-gitops-repo.git"
+  branch: main
+  path: "clusters/my-nebari-custom-tls"
+  auth:
+    ssh_key_env: GIT_SSH_PRIVATE_KEY

--- a/pkg/argocd/certificate.go
+++ b/pkg/argocd/certificate.go
@@ -149,8 +149,8 @@ func createGatewayTLSSecret(ctx context.Context, client kubernetes.Interface, cf
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
-				"app.kubernetes.io/name":       "nebari-gateway",
-				"app.kubernetes.io/managed-by": "nebari-infrastructure-core",
+				"app.kubernetes.io/name": "nebari-gateway",
+				ManagedByLabel:           NebariManagedByValue,
 			},
 		},
 		Type: corev1.SecretTypeTLS,

--- a/pkg/argocd/certificate.go
+++ b/pkg/argocd/certificate.go
@@ -1,0 +1,255 @@
+package argocd
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/nebari-dev/nebari-infrastructure-core/pkg/config"
+	"github.com/nebari-dev/nebari-infrastructure-core/pkg/status"
+)
+
+// PreflightGatewayTLS validates user-supplied certificate material for the
+// files and env sources before any cluster mutation or GitOps commit, so a bad
+// path, unset env var, or mismatched keypair fails the deploy fast instead of
+// silently rendering a gateway that can never terminate TLS.
+//
+// It is a no-op for non-existing certificate types and for the existing_secret
+// source (which is validated against the live cluster during ConfigureGatewayTLS).
+// No certificate or key material is logged.
+func PreflightGatewayTLS(cfg *config.NebariConfig) error {
+	cert := cfg.Certificate
+	if cert == nil || cert.Type != config.CertificateTypeExisting {
+		return nil
+	}
+
+	var certPEM, keyPEM []byte
+	var err error
+	switch {
+	case cert.Files != nil:
+		certPEM, keyPEM, err = readCertFiles(cert.Files)
+	case cert.Env != nil:
+		certPEM, keyPEM, err = readCertEnv(cert.Env)
+	default:
+		// existing_secret is validated against the cluster later.
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if _, err := tls.X509KeyPair(certPEM, keyPEM); err != nil {
+		return fmt.Errorf("invalid TLS certificate/key pair: %w", err)
+	}
+	return nil
+}
+
+// ConfigureGatewayTLS handles user-supplied TLS certificates
+// (certificate.type=existing). For the files and env sources it reads the PEM
+// material and creates a kubernetes.io/tls secret directly in
+// envoy-gateway-system. For the existing_secret source it fetches the
+// already-present secret. For every source it parses the resolved certificate
+// and warns (never fails) when a recommended SAN is missing.
+//
+// Certificate and key material is never logged or recorded in span attributes.
+// For non-existing certificate types this is a no-op.
+func ConfigureGatewayTLS(ctx context.Context, client kubernetes.Interface, cfg *config.NebariConfig) error {
+	cert := cfg.Certificate
+	if cert == nil || cert.Type != config.CertificateTypeExisting {
+		return nil
+	}
+
+	tracer := otel.Tracer("nebari-infrastructure-core")
+	ctx, span := tracer.Start(ctx, "argocd.ConfigureGatewayTLS")
+	defer span.End()
+
+	switch {
+	case cert.Files != nil:
+		span.SetAttributes(attribute.String("source", "files"))
+		certPEM, keyPEM, err := readCertFiles(cert.Files)
+		if err != nil {
+			span.RecordError(err)
+			return err
+		}
+		return createGatewayTLSSecret(ctx, client, cfg, certPEM, keyPEM)
+	case cert.Env != nil:
+		span.SetAttributes(attribute.String("source", "env"))
+		certPEM, keyPEM, err := readCertEnv(cert.Env)
+		if err != nil {
+			span.RecordError(err)
+			return err
+		}
+		return createGatewayTLSSecret(ctx, client, cfg, certPEM, keyPEM)
+	case cert.ExistingSecret != nil:
+		span.SetAttributes(attribute.String("source", "existing_secret"))
+		checkExistingSecretSANs(ctx, client, cfg)
+		return nil
+	default:
+		// Validation guarantees exactly one source; defensive no-op.
+		return nil
+	}
+}
+
+// readCertFiles reads PEM cert/key material from disk.
+func readCertFiles(files *config.CertFiles) (certPEM, keyPEM []byte, err error) {
+	certPEM, err = os.ReadFile(files.CertFile)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read certificate file %q: %w", files.CertFile, err)
+	}
+	keyPEM, err = os.ReadFile(files.KeyFile)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read key file %q: %w", files.KeyFile, err)
+	}
+	return certPEM, keyPEM, nil
+}
+
+// readCertEnv reads raw (non-base64) PEM cert/key material from environment variables.
+func readCertEnv(env *config.CertEnv) (certPEM, keyPEM []byte, err error) {
+	certStr := os.Getenv(env.CertEnv)
+	if certStr == "" {
+		return nil, nil, fmt.Errorf("certificate env var %q is empty or unset", env.CertEnv)
+	}
+	keyStr := os.Getenv(env.KeyEnv)
+	if keyStr == "" {
+		return nil, nil, fmt.Errorf("key env var %q is empty or unset", env.KeyEnv)
+	}
+	return []byte(certStr), []byte(keyStr), nil
+}
+
+// createGatewayTLSSecret validates the keypair, warns on missing SANs, and
+// creates (or updates) the kubernetes.io/tls secret in envoy-gateway-system.
+func createGatewayTLSSecret(ctx context.Context, client kubernetes.Interface, cfg *config.NebariConfig, certPEM, keyPEM []byte) error {
+	// Fail fast on a malformed or mismatched keypair.
+	if _, err := tls.X509KeyPair(certPEM, keyPEM); err != nil {
+		return fmt.Errorf("invalid TLS certificate/key pair: %w", err)
+	}
+
+	warnOnMissingSANs(ctx, certPEM, cfg.Domain)
+
+	name := cfg.Certificate.ResolvedSecretName()
+	namespace := config.DefaultGatewayTLSNamespace
+
+	// The gateway expects the secret in envoy-gateway-system, which may not
+	// exist yet (envoy-gateway is installed via Argo CD afterwards).
+	if err := createNamespace(ctx, client, namespace); err != nil {
+		return fmt.Errorf("ensure namespace %s: %w", namespace, err)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "nebari-gateway",
+				"app.kubernetes.io/managed-by": "nebari-infrastructure-core",
+			},
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       certPEM,
+			corev1.TLSPrivateKeyKey: keyPEM,
+		},
+	}
+
+	status.Send(ctx, status.NewUpdate(status.LevelProgress, "Configuring user-supplied gateway TLS secret").
+		WithResource("certificate").
+		WithAction("configuring").
+		WithMetadata("secret", name).
+		WithMetadata("namespace", namespace))
+
+	_, err := client.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if _, createErr := client.CoreV1().Secrets(namespace).Create(ctx, secret, metav1.CreateOptions{}); createErr != nil {
+			return fmt.Errorf("create gateway TLS secret %s/%s: %w", namespace, name, createErr)
+		}
+	} else if _, updateErr := client.CoreV1().Secrets(namespace).Update(ctx, secret, metav1.UpdateOptions{}); updateErr != nil {
+		return fmt.Errorf("update gateway TLS secret %s/%s: %w", namespace, name, updateErr)
+	}
+
+	status.Send(ctx, status.NewUpdate(status.LevelSuccess, "Gateway TLS secret configured from user-supplied certificate").
+		WithResource("certificate").
+		WithAction("configured").
+		WithMetadata("secret", name).
+		WithMetadata("namespace", namespace))
+	return nil
+}
+
+// checkExistingSecretSANs fetches a user-managed TLS secret and warns when the
+// certificate is missing recommended SANs. Failures are non-fatal: the secret
+// may be created out-of-band, and SAN coverage is advisory.
+func checkExistingSecretSANs(ctx context.Context, client kubernetes.Interface, cfg *config.NebariConfig) {
+	name, namespace := cfg.Certificate.GatewaySecretRef()
+
+	secret, err := client.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		status.Send(ctx, status.NewUpdate(status.LevelWarning,
+			"Could not fetch user-supplied TLS secret to verify SANs; ensure it exists before traffic is served").
+			WithMetadata("secret", name).
+			WithMetadata("namespace", namespace).
+			WithMetadata("error", err.Error()))
+		return
+	}
+
+	certPEM, ok := secret.Data[corev1.TLSCertKey]
+	if !ok {
+		status.Send(ctx, status.NewUpdate(status.LevelWarning,
+			fmt.Sprintf("TLS secret %s/%s has no %s key", namespace, name, corev1.TLSCertKey)).
+			WithMetadata("secret", name).
+			WithMetadata("namespace", namespace))
+		return
+	}
+	warnOnMissingSANs(ctx, certPEM, cfg.Domain)
+}
+
+// warnOnMissingSANs warns (does not fail) when the certificate does not cover
+// the apex domain or the keycloak/argocd subdomains. Hard-failing would block
+// legitimate setups whose certs carry extra hostnames we don't track.
+func warnOnMissingSANs(ctx context.Context, certPEM []byte, domain string) {
+	if domain == "" {
+		return
+	}
+	missing, err := missingSANs(certPEM, domain)
+	if err != nil {
+		status.Send(ctx, status.NewUpdate(status.LevelWarning,
+			"Could not parse user-supplied TLS certificate to verify SANs").
+			WithMetadata("error", err.Error()))
+		return
+	}
+	if len(missing) > 0 {
+		status.Send(ctx, status.NewUpdate(status.LevelWarning,
+			"User-supplied TLS certificate is missing recommended SANs; some hostnames may fail TLS").
+			WithMetadata("missing_hosts", strings.Join(missing, ", ")))
+	}
+}
+
+// missingSANs parses certPEM and returns the subset of the required gateway
+// hostnames (apex, keycloak.<domain>, argocd.<domain>) the certificate does not
+// cover. Wildcard SANs are honored via x509.Certificate.VerifyHostname.
+func missingSANs(certPEM []byte, domain string) ([]string, error) {
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found in certificate")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse certificate: %w", err)
+	}
+
+	required := []string{domain, "keycloak." + domain, "argocd." + domain}
+	var missing []string
+	for _, host := range required {
+		if cert.VerifyHostname(host) != nil {
+			missing = append(missing, host)
+		}
+	}
+	return missing, nil
+}

--- a/pkg/argocd/certificate.go
+++ b/pkg/argocd/certificate.go
@@ -62,6 +62,11 @@ func PreflightGatewayTLS(cfg *config.NebariConfig) error {
 //
 // Certificate and key material is never logged or recorded in span attributes.
 // For non-existing certificate types this is a no-op.
+//
+// A non-nil error is only ever returned for the files/env sources, where this is
+// the sole step that places the secret in the cluster; the existing_secret source
+// is advisory-only and always returns nil. Callers therefore treat any error here
+// as fatal without needing to branch on the source.
 func ConfigureGatewayTLS(ctx context.Context, client kubernetes.Interface, cfg *config.NebariConfig) error {
 	cert := cfg.Certificate
 	if cert == nil || cert.Type != config.CertificateTypeExisting {

--- a/pkg/argocd/certificate_secret_test.go
+++ b/pkg/argocd/certificate_secret_test.go
@@ -1,0 +1,322 @@
+package argocd
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/nebari-dev/nebari-infrastructure-core/pkg/config"
+)
+
+// genTestCert returns PEM-encoded cert and key for the given SANs.
+func genTestCert(t *testing.T, sans ...string) (certPEM, keyPEM []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		DNSNames:     sans,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM
+}
+
+func TestMissingSANs(t *testing.T) {
+	tests := []struct {
+		name    string
+		sans    []string
+		domain  string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:   "all present",
+			sans:   []string{"example.com", "keycloak.example.com", "argocd.example.com"},
+			domain: "example.com",
+			want:   nil,
+		},
+		{
+			name:   "wildcard plus apex covers all",
+			sans:   []string{"example.com", "*.example.com"},
+			domain: "example.com",
+			want:   nil,
+		},
+		{
+			name:   "missing keycloak and argocd",
+			sans:   []string{"example.com"},
+			domain: "example.com",
+			want:   []string{"keycloak.example.com", "argocd.example.com"},
+		},
+		{
+			name:    "unparseable cert",
+			domain:  "example.com",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var certPEM []byte
+			if tt.wantErr {
+				certPEM = []byte("not a pem")
+			} else {
+				certPEM, _ = genTestCert(t, tt.sans...)
+			}
+			got, err := missingSANs(certPEM, tt.domain)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("missingSANs() error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("missingSANs() = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("missingSANs()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestConfigureGatewayTLS_FilesSource(t *testing.T) {
+	ctx := context.Background()
+	certPEM, keyPEM := genTestCert(t, "example.com", "keycloak.example.com", "argocd.example.com")
+
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "tls.crt")
+	keyPath := filepath.Join(dir, "tls.key")
+	if err := os.WriteFile(certPath, certPEM, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.NebariConfig{
+		Domain: "example.com",
+		Certificate: &config.CertificateConfig{
+			Type:  "existing",
+			Files: &config.CertFiles{CertFile: certPath, KeyFile: keyPath},
+		},
+	}
+
+	client := fake.NewSimpleClientset() //nolint:staticcheck // SA1019: fine for tests
+	if err := ConfigureGatewayTLS(ctx, client, cfg); err != nil {
+		t.Fatalf("ConfigureGatewayTLS() error: %v", err)
+	}
+
+	secret, err := client.CoreV1().Secrets("envoy-gateway-system").Get(ctx, "nebari-gateway-tls", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected secret to be created: %v", err)
+	}
+	if secret.Type != corev1.SecretTypeTLS {
+		t.Errorf("secret type = %q, want %q", secret.Type, corev1.SecretTypeTLS)
+	}
+	if string(secret.Data["tls.crt"]) != string(certPEM) {
+		t.Error("tls.crt mismatch")
+	}
+	if string(secret.Data["tls.key"]) != string(keyPEM) {
+		t.Error("tls.key mismatch")
+	}
+}
+
+func TestConfigureGatewayTLS_EnvSource_CustomName(t *testing.T) {
+	ctx := context.Background()
+	certPEM, keyPEM := genTestCert(t, "example.com")
+
+	t.Setenv("TEST_TLS_CERT", string(certPEM))
+	t.Setenv("TEST_TLS_KEY", string(keyPEM))
+
+	cfg := &config.NebariConfig{
+		Domain: "example.com",
+		Certificate: &config.CertificateConfig{
+			Type:       "existing",
+			SecretName: "custom-tls",
+			Env:        &config.CertEnv{CertEnv: "TEST_TLS_CERT", KeyEnv: "TEST_TLS_KEY"},
+		},
+	}
+
+	client := fake.NewSimpleClientset() //nolint:staticcheck // SA1019: fine for tests
+	if err := ConfigureGatewayTLS(ctx, client, cfg); err != nil {
+		t.Fatalf("ConfigureGatewayTLS() error: %v", err)
+	}
+
+	if _, err := client.CoreV1().Secrets("envoy-gateway-system").Get(ctx, "custom-tls", metav1.GetOptions{}); err != nil {
+		t.Fatalf("expected secret custom-tls to be created: %v", err)
+	}
+}
+
+func TestConfigureGatewayTLS_Idempotent(t *testing.T) {
+	ctx := context.Background()
+	certPEM, keyPEM := genTestCert(t, "example.com")
+	t.Setenv("TEST_TLS_CERT", string(certPEM))
+	t.Setenv("TEST_TLS_KEY", string(keyPEM))
+
+	cfg := &config.NebariConfig{
+		Domain: "example.com",
+		Certificate: &config.CertificateConfig{
+			Type: "existing",
+			Env:  &config.CertEnv{CertEnv: "TEST_TLS_CERT", KeyEnv: "TEST_TLS_KEY"},
+		},
+	}
+	client := fake.NewSimpleClientset() //nolint:staticcheck // SA1019: fine for tests
+	if err := ConfigureGatewayTLS(ctx, client, cfg); err != nil {
+		t.Fatalf("first call error: %v", err)
+	}
+	// Second call should update without error.
+	if err := ConfigureGatewayTLS(ctx, client, cfg); err != nil {
+		t.Fatalf("second call error: %v", err)
+	}
+}
+
+func TestConfigureGatewayTLS_MissingFile(t *testing.T) {
+	ctx := context.Background()
+	cfg := &config.NebariConfig{
+		Domain: "example.com",
+		Certificate: &config.CertificateConfig{
+			Type:  "existing",
+			Files: &config.CertFiles{CertFile: "/nonexistent/tls.crt", KeyFile: "/nonexistent/tls.key"},
+		},
+	}
+	client := fake.NewSimpleClientset() //nolint:staticcheck // SA1019: fine for tests
+	if err := ConfigureGatewayTLS(ctx, client, cfg); err == nil {
+		t.Fatal("expected error for missing cert file, got nil")
+	}
+}
+
+func TestConfigureGatewayTLS_NonExistingTypeIsNoop(t *testing.T) {
+	ctx := context.Background()
+	cfg := &config.NebariConfig{Domain: "example.com", Certificate: &config.CertificateConfig{Type: "selfsigned"}}
+	client := fake.NewSimpleClientset() //nolint:staticcheck // SA1019: fine for tests
+	if err := ConfigureGatewayTLS(ctx, client, cfg); err != nil {
+		t.Fatalf("ConfigureGatewayTLS() should be a no-op for selfsigned, got: %v", err)
+	}
+	secrets, _ := client.CoreV1().Secrets("envoy-gateway-system").List(ctx, metav1.ListOptions{})
+	if len(secrets.Items) != 0 {
+		t.Errorf("expected no secrets created for non-existing type, got %d", len(secrets.Items))
+	}
+}
+
+func TestPreflightGatewayTLS(t *testing.T) {
+	certPEM, keyPEM := genTestCert(t, "example.com")
+	otherKeyPEM := func() []byte {
+		_, k := genTestCert(t, "other.com")
+		return k
+	}()
+
+	dir := t.TempDir()
+	goodCert := filepath.Join(dir, "tls.crt")
+	goodKey := filepath.Join(dir, "tls.key")
+	mismatchKey := filepath.Join(dir, "other.key")
+	for path, data := range map[string][]byte{goodCert: certPEM, goodKey: keyPEM, mismatchKey: otherKeyPEM} {
+		if err := os.WriteFile(path, data, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tests := []struct {
+		name    string
+		cfg     *config.CertificateConfig
+		setEnv  map[string]string
+		wantErr bool
+	}{
+		{name: "nil certificate", cfg: nil},
+		{name: "non-existing type", cfg: &config.CertificateConfig{Type: "selfsigned"}},
+		{name: "existing_secret deferred to cluster", cfg: &config.CertificateConfig{Type: "existing", ExistingSecret: &config.ExistingSecretRef{Name: "x"}}},
+		{
+			name: "valid files",
+			cfg:  &config.CertificateConfig{Type: "existing", Files: &config.CertFiles{CertFile: goodCert, KeyFile: goodKey}},
+		},
+		{
+			name:    "missing file",
+			cfg:     &config.CertificateConfig{Type: "existing", Files: &config.CertFiles{CertFile: "/nope.crt", KeyFile: "/nope.key"}},
+			wantErr: true,
+		},
+		{
+			name:    "mismatched keypair",
+			cfg:     &config.CertificateConfig{Type: "existing", Files: &config.CertFiles{CertFile: goodCert, KeyFile: mismatchKey}},
+			wantErr: true,
+		},
+		{
+			name:    "unset env",
+			cfg:     &config.CertificateConfig{Type: "existing", Env: &config.CertEnv{CertEnv: "PREFLIGHT_UNSET_CERT", KeyEnv: "PREFLIGHT_UNSET_KEY"}},
+			wantErr: true,
+		},
+		{
+			name:   "valid env",
+			cfg:    &config.CertificateConfig{Type: "existing", Env: &config.CertEnv{CertEnv: "PREFLIGHT_CERT", KeyEnv: "PREFLIGHT_KEY"}},
+			setEnv: map[string]string{"PREFLIGHT_CERT": string(certPEM), "PREFLIGHT_KEY": string(keyPEM)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.setEnv {
+				t.Setenv(k, v)
+			}
+			cfg := &config.NebariConfig{Domain: "example.com", Certificate: tt.cfg}
+			err := PreflightGatewayTLS(cfg)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestConfigureGatewayTLS_ExistingSecretSANCheck(t *testing.T) {
+	ctx := context.Background()
+	certPEM, _ := genTestCert(t, "example.com", "keycloak.example.com", "argocd.example.com")
+
+	existing := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "user-tls", Namespace: "envoy-gateway-system"},
+		Type:       corev1.SecretTypeTLS,
+		Data:       map[string][]byte{"tls.crt": certPEM, "tls.key": []byte("ignored")},
+	}
+	cfg := &config.NebariConfig{
+		Domain: "example.com",
+		Certificate: &config.CertificateConfig{
+			Type:           "existing",
+			ExistingSecret: &config.ExistingSecretRef{Name: "user-tls"},
+		},
+	}
+	client := fake.NewSimpleClientset(existing) //nolint:staticcheck // SA1019: fine for tests
+	// existing_secret path must not error and must not create/overwrite a secret.
+	if err := ConfigureGatewayTLS(ctx, client, cfg); err != nil {
+		t.Fatalf("ConfigureGatewayTLS() error: %v", err)
+	}
+}

--- a/pkg/argocd/certificate_test.go
+++ b/pkg/argocd/certificate_test.go
@@ -1,0 +1,247 @@
+package argocd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nebari-dev/nebari-infrastructure-core/pkg/config"
+	"github.com/nebari-dev/nebari-infrastructure-core/pkg/provider"
+)
+
+func TestNewTemplateData_Certificate(t *testing.T) {
+	settings := provider.InfraSettings{}
+
+	tests := []struct {
+		name              string
+		cert              *config.CertificateConfig
+		wantSecretName    string
+		wantSecretNS      string
+		wantCrossNS       bool
+		wantExisting      bool
+		wantIssuerNonZero bool
+	}{
+		{
+			name:              "no certificate uses defaults + selfsigned issuer",
+			cert:              nil,
+			wantSecretName:    "nebari-gateway-tls",
+			wantSecretNS:      "envoy-gateway-system",
+			wantCrossNS:       false,
+			wantExisting:      false,
+			wantIssuerNonZero: true,
+		},
+		{
+			name:           "existing files source",
+			cert:           &config.CertificateConfig{Type: "existing", Files: &config.CertFiles{CertFile: "/c", KeyFile: "/k"}},
+			wantSecretName: "nebari-gateway-tls",
+			wantSecretNS:   "envoy-gateway-system",
+			wantCrossNS:    false,
+			wantExisting:   true,
+		},
+		{
+			name:           "existing files with custom secret name",
+			cert:           &config.CertificateConfig{Type: "existing", SecretName: "custom-tls", Env: &config.CertEnv{CertEnv: "A", KeyEnv: "B"}},
+			wantSecretName: "custom-tls",
+			wantSecretNS:   "envoy-gateway-system",
+			wantExisting:   true,
+		},
+		{
+			name:           "existing_secret same namespace",
+			cert:           &config.CertificateConfig{Type: "existing", ExistingSecret: &config.ExistingSecretRef{Name: "user-tls"}},
+			wantSecretName: "user-tls",
+			wantSecretNS:   "envoy-gateway-system",
+			wantCrossNS:    false,
+			wantExisting:   true,
+		},
+		{
+			name:           "existing_secret cross namespace",
+			cert:           &config.CertificateConfig{Type: "existing", ExistingSecret: &config.ExistingSecretRef{Name: "user-tls", Namespace: "user-ns"}},
+			wantSecretName: "user-tls",
+			wantSecretNS:   "user-ns",
+			wantCrossNS:    true,
+			wantExisting:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.NebariConfig{Domain: "test.example.com", Certificate: tt.cert}
+			data := NewTemplateData(cfg, nil, settings)
+
+			if data.GatewayTLSSecretName != tt.wantSecretName {
+				t.Errorf("GatewayTLSSecretName = %q, want %q", data.GatewayTLSSecretName, tt.wantSecretName)
+			}
+			if data.GatewayTLSSecretNamespace != tt.wantSecretNS {
+				t.Errorf("GatewayTLSSecretNamespace = %q, want %q", data.GatewayTLSSecretNamespace, tt.wantSecretNS)
+			}
+			if data.GatewayTLSCrossNamespace != tt.wantCrossNS {
+				t.Errorf("GatewayTLSCrossNamespace = %v, want %v", data.GatewayTLSCrossNamespace, tt.wantCrossNS)
+			}
+			if data.UseExistingCertificate != tt.wantExisting {
+				t.Errorf("UseExistingCertificate = %v, want %v", data.UseExistingCertificate, tt.wantExisting)
+			}
+			if tt.wantIssuerNonZero && data.CertificateIssuer == "" {
+				t.Error("CertificateIssuer should be set for non-existing types")
+			}
+		})
+	}
+}
+
+func TestGatewayTemplate_CertificateRefName(t *testing.T) {
+	content, err := templates.ReadFile("templates/manifests/networking/gateway.yaml")
+	if err != nil {
+		t.Fatalf("failed to read gateway template: %v", err)
+	}
+
+	t.Run("same namespace omits namespace field", func(t *testing.T) {
+		data := TemplateData{
+			Domain:                    "test.example.com",
+			HTTPSPort:                 443,
+			GatewayTLSSecretName:      "user-tls",
+			GatewayTLSSecretNamespace: "envoy-gateway-system",
+			GatewayTLSCrossNamespace:  false,
+		}
+		processed, err := processTemplate("manifests/networking/gateway.yaml", content, data)
+		if err != nil {
+			t.Fatalf("processTemplate() error: %v", err)
+		}
+		output := string(processed)
+		if !strings.Contains(output, "name: user-tls") {
+			t.Errorf("expected certificateRef name user-tls, got:\n%s", output)
+		}
+		// The certificateRef namespace is indented under the ref (12 spaces);
+		// the Gateway's own metadata.namespace (2 spaces) is unrelated.
+		if strings.Contains(output, "            namespace:") {
+			t.Errorf("same-namespace ref should not set namespace on certificateRefs, got:\n%s", output)
+		}
+	})
+
+	t.Run("cross namespace sets namespace field", func(t *testing.T) {
+		data := TemplateData{
+			Domain:                    "test.example.com",
+			HTTPSPort:                 443,
+			GatewayTLSSecretName:      "user-tls",
+			GatewayTLSSecretNamespace: "user-ns",
+			GatewayTLSCrossNamespace:  true,
+		}
+		processed, err := processTemplate("manifests/networking/gateway.yaml", content, data)
+		if err != nil {
+			t.Fatalf("processTemplate() error: %v", err)
+		}
+		output := string(processed)
+		if !strings.Contains(output, "name: user-tls") {
+			t.Errorf("expected certificateRef name user-tls, got:\n%s", output)
+		}
+		if !strings.Contains(output, "namespace: user-ns") {
+			t.Errorf("cross-namespace ref should set namespace user-ns, got:\n%s", output)
+		}
+	})
+}
+
+func TestReferenceGrantTemplate(t *testing.T) {
+	content, err := templates.ReadFile("templates/manifests/networking/gateway-tls-referencegrant.yaml")
+	if err != nil {
+		t.Fatalf("failed to read referencegrant template: %v", err)
+	}
+	data := TemplateData{
+		GatewayTLSSecretName:      "user-tls",
+		GatewayTLSSecretNamespace: "user-ns",
+		GatewayTLSCrossNamespace:  true,
+	}
+	processed, err := processTemplate("manifests/networking/gateway-tls-referencegrant.yaml", content, data)
+	if err != nil {
+		t.Fatalf("processTemplate() error: %v", err)
+	}
+	output := string(processed)
+	if !strings.Contains(output, "kind: ReferenceGrant") {
+		t.Errorf("expected kind: ReferenceGrant, got:\n%s", output)
+	}
+	if !strings.Contains(output, "namespace: user-ns") {
+		t.Errorf("ReferenceGrant should live in user-ns, got:\n%s", output)
+	}
+	if !strings.Contains(output, "name: user-tls") {
+		t.Errorf("ReferenceGrant should grant access to user-tls, got:\n%s", output)
+	}
+	if !strings.Contains(output, "namespace: envoy-gateway-system") {
+		t.Errorf("ReferenceGrant from clause should reference envoy-gateway-system, got:\n%s", output)
+	}
+}
+
+func TestWriteAllToGit_SkipsCertManagerForExisting(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	cfg := &config.NebariConfig{
+		Domain: "test.example.com",
+		Certificate: &config.CertificateConfig{
+			Type:           "existing",
+			ExistingSecret: &config.ExistingSecretRef{Name: "user-tls"},
+		},
+	}
+	mock := &mockGitClient{workDir: tmpDir}
+	if err := WriteAllToGit(ctx, mock, cfg, nil, provider.InfraSettings{}); err != nil {
+		t.Fatalf("WriteAllToGit() error: %v", err)
+	}
+
+	certPath := filepath.Join(tmpDir, "manifests", "security", "certificates", "gateway-certificate.yaml")
+	if _, err := os.Stat(certPath); !os.IsNotExist(err) {
+		t.Errorf("expected gateway-certificate.yaml to be skipped for type=existing, but it exists")
+	}
+
+	// The certificates Application must also be skipped, otherwise it would sync
+	// an empty directory (allowEmpty: false) and report as failed.
+	appPath := filepath.Join(tmpDir, "apps", "certificates.yaml")
+	if _, err := os.Stat(appPath); !os.IsNotExist(err) {
+		t.Errorf("expected apps/certificates.yaml to be skipped for type=existing, but it exists")
+	}
+
+	// Same-namespace existing_secret should not emit a ReferenceGrant.
+	rgPath := filepath.Join(tmpDir, "manifests", "networking", "gateway-tls-referencegrant.yaml")
+	if _, err := os.Stat(rgPath); !os.IsNotExist(err) {
+		t.Errorf("expected no ReferenceGrant for same-namespace secret, but it exists")
+	}
+}
+
+func TestWriteAllToGit_RendersCertManagerForSelfSigned(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	cfg := &config.NebariConfig{Domain: "test.example.com"}
+	mock := &mockGitClient{workDir: tmpDir}
+	if err := WriteAllToGit(ctx, mock, cfg, nil, provider.InfraSettings{}); err != nil {
+		t.Fatalf("WriteAllToGit() error: %v", err)
+	}
+
+	certPath := filepath.Join(tmpDir, "manifests", "security", "certificates", "gateway-certificate.yaml")
+	if _, err := os.Stat(certPath); os.IsNotExist(err) {
+		t.Error("expected gateway-certificate.yaml to be rendered for selfsigned default")
+	}
+	appPath := filepath.Join(tmpDir, "apps", "certificates.yaml")
+	if _, err := os.Stat(appPath); os.IsNotExist(err) {
+		t.Error("expected apps/certificates.yaml to be rendered for selfsigned default")
+	}
+}
+
+func TestWriteAllToGit_RendersReferenceGrantCrossNamespace(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	cfg := &config.NebariConfig{
+		Domain: "test.example.com",
+		Certificate: &config.CertificateConfig{
+			Type:           "existing",
+			ExistingSecret: &config.ExistingSecretRef{Name: "user-tls", Namespace: "user-ns"},
+		},
+	}
+	mock := &mockGitClient{workDir: tmpDir}
+	if err := WriteAllToGit(ctx, mock, cfg, nil, provider.InfraSettings{}); err != nil {
+		t.Fatalf("WriteAllToGit() error: %v", err)
+	}
+
+	rgPath := filepath.Join(tmpDir, "manifests", "networking", "gateway-tls-referencegrant.yaml")
+	if _, err := os.Stat(rgPath); os.IsNotExist(err) {
+		t.Error("expected ReferenceGrant to be rendered for cross-namespace existing_secret")
+	}
+}

--- a/pkg/argocd/foundational.go
+++ b/pkg/argocd/foundational.go
@@ -32,6 +32,12 @@ const (
 
 	// NebariFoundationalPartOf is the value of the app.kubernetes.io/part-of label for foundational resources.
 	NebariFoundationalPartOf = "nebari-foundational"
+
+	// ManagedByLabel is the app.kubernetes.io/managed-by label key.
+	ManagedByLabel = "app.kubernetes.io/managed-by"
+
+	// NebariManagedByValue is the value of the app.kubernetes.io/managed-by label for Nebari-managed resources.
+	NebariManagedByValue = "nebari-infrastructure-core"
 )
 
 // FoundationalConfig holds configuration for foundational services
@@ -287,8 +293,8 @@ func createKeycloakSecrets(ctx context.Context, client kubernetes.Interface, key
 				Name:      "nebari-realm-admin-credentials",
 				Namespace: namespace,
 				Labels: map[string]string{
-					"app.kubernetes.io/part-of":    NebariFoundationalPartOf,
-					"app.kubernetes.io/managed-by": "nebari-infrastructure-core",
+					"app.kubernetes.io/part-of": NebariFoundationalPartOf,
+					ManagedByLabel:              NebariManagedByValue,
 				},
 			},
 			Type: corev1.SecretTypeOpaque,
@@ -308,8 +314,8 @@ func createKeycloakSecrets(ctx context.Context, client kubernetes.Interface, key
 				Name:      "argocd-oidc-client-secret",
 				Namespace: namespace,
 				Labels: map[string]string{
-					"app.kubernetes.io/part-of":    NebariFoundationalPartOf,
-					"app.kubernetes.io/managed-by": "nebari-infrastructure-core",
+					"app.kubernetes.io/part-of": NebariFoundationalPartOf,
+					ManagedByLabel:              NebariManagedByValue,
 				},
 			},
 			Type: corev1.SecretTypeOpaque,
@@ -335,8 +341,8 @@ func createLandingPageSecrets(ctx context.Context, client kubernetes.Interface, 
 			Name:      NebariLandingRedisSecretName,
 			Namespace: namespace,
 			Labels: map[string]string{
-				"app.kubernetes.io/part-of":    NebariFoundationalPartOf,
-				"app.kubernetes.io/managed-by": "nebari-infrastructure-core",
+				"app.kubernetes.io/part-of": NebariFoundationalPartOf,
+				ManagedByLabel:              NebariManagedByValue,
 			},
 		},
 		Type: corev1.SecretTypeOpaque,

--- a/pkg/argocd/install.go
+++ b/pkg/argocd/install.go
@@ -147,6 +147,21 @@ func Install(ctx context.Context, cfg *config.NebariConfig, prov provider.Provid
 		}
 	}
 
+	// Configure a user-supplied gateway TLS certificate (certificate.type=existing).
+	// No-op for cert-manager-issued certs. For files/env sources this creates the
+	// kubernetes.io/tls secret; for existing_secret it performs an advisory SAN check.
+	if err := ConfigureGatewayTLS(ctx, k8sClient, cfg); err != nil {
+		span.RecordError(err)
+		status.Send(ctx, status.NewUpdate(status.LevelWarning, "Failed to configure gateway TLS certificate").
+			WithResource("certificate").
+			WithAction("tls-config-failed").
+			WithMetadata("error", err.Error()))
+		status.Warning(ctx, "Gateway HTTPS may not work until the TLS secret exists in envoy-gateway-system")
+		// Don't fail the overall install - surfaced as a warning so the rest of the deploy proceeds.
+		// Files/env material is pre-validated at deploy start, so a failure here is a
+		// transient cluster/secret-creation issue rather than a local config error.
+	}
+
 	span.SetAttributes(
 		attribute.String("argocd_version", argoCDCfg.Version),
 		attribute.String("argocd_namespace", argoCDCfg.Namespace),

--- a/pkg/argocd/install.go
+++ b/pkg/argocd/install.go
@@ -148,18 +148,24 @@ func Install(ctx context.Context, cfg *config.NebariConfig, prov provider.Provid
 	}
 
 	// Configure a user-supplied gateway TLS certificate (certificate.type=existing).
-	// No-op for cert-manager-issued certs. For files/env sources this creates the
-	// kubernetes.io/tls secret; for existing_secret it performs an advisory SAN check.
+	// No-op for cert-manager-issued certs.
+	//
+	// For the files/env sources this is the only step that materializes the
+	// kubernetes.io/tls secret in the cluster, so a failure here leaves the gateway
+	// with no usable cert. The material is already validated locally during
+	// preflight, so a failure at this point is a real cluster-side error
+	// (RBAC/quota/secret creation) - treat it as fatal rather than reporting a
+	// misleading success with a silently-broken gateway.
+	//
+	// The existing_secret source only performs an advisory SAN check and never
+	// returns an error, so this remains non-fatal for that source.
 	if err := ConfigureGatewayTLS(ctx, k8sClient, cfg); err != nil {
 		span.RecordError(err)
-		status.Send(ctx, status.NewUpdate(status.LevelWarning, "Failed to configure gateway TLS certificate").
+		status.Send(ctx, status.NewUpdate(status.LevelError, "Failed to configure gateway TLS certificate").
 			WithResource("certificate").
 			WithAction("tls-config-failed").
 			WithMetadata("error", err.Error()))
-		status.Warning(ctx, "Gateway HTTPS may not work until the TLS secret exists in envoy-gateway-system")
-		// Don't fail the overall install - surfaced as a warning so the rest of the deploy proceeds.
-		// Files/env material is pre-validated at deploy start, so a failure here is a
-		// transient cluster/secret-creation issue rather than a local config error.
+		return fmt.Errorf("configure gateway TLS certificate: %w", err)
 	}
 
 	span.SetAttributes(

--- a/pkg/argocd/templates/manifests/networking/gateway-tls-referencegrant.yaml
+++ b/pkg/argocd/templates/manifests/networking/gateway-tls-referencegrant.yaml
@@ -1,0 +1,20 @@
+# Rendered only when certificate.type=existing references a secret outside
+# envoy-gateway-system. Grants the Nebari Gateway permission to read the
+# user-supplied TLS secret from its own namespace.
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: nebari-gateway-tls-grant
+  namespace: {{ .GatewayTLSSecretNamespace }}
+  labels:
+    app.kubernetes.io/name: nebari-gateway
+    app.kubernetes.io/managed-by: nebari-infrastructure-core
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: envoy-gateway-system
+  to:
+    - group: ""
+      kind: Secret
+      name: {{ .GatewayTLSSecretName }}

--- a/pkg/argocd/templates/manifests/networking/gateway.yaml
+++ b/pkg/argocd/templates/manifests/networking/gateway.yaml
@@ -31,5 +31,8 @@ spec:
       tls:
         mode: Terminate
         certificateRefs:
-          - name: nebari-gateway-tls
+          - name: {{ .GatewayTLSSecretName }}
             kind: Secret
+{{- if .GatewayTLSCrossNamespace }}
+            namespace: {{ .GatewayTLSSecretNamespace }}
+{{- end }}

--- a/pkg/argocd/templates/manifests/security/certificates/gateway-certificate.yaml
+++ b/pkg/argocd/templates/manifests/security/certificates/gateway-certificate.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: nebari-gateway
     app.kubernetes.io/managed-by: nebari-infrastructure-core
 spec:
-  secretName: nebari-gateway-tls
+  secretName: {{ .GatewayTLSSecretName }}
   duration: 8760h # 1 year
   renewBefore: 720h # 30 days
   issuerRef:

--- a/pkg/argocd/writer.go
+++ b/pkg/argocd/writer.go
@@ -49,6 +49,19 @@ type TemplateData struct {
 	ACMEEmail         string
 	ACMEServer        string
 
+	// UseExistingCertificate is true when the user supplies their own TLS cert
+	// (certificate.type=existing). When true, the cert-manager Certificate is
+	// not rendered.
+	UseExistingCertificate bool
+	// GatewayTLSSecretName is the name of the TLS secret the gateway listener references.
+	GatewayTLSSecretName string
+	// GatewayTLSSecretNamespace is the namespace of that secret. Only emitted on the
+	// gateway certificateRef (and used for the ReferenceGrant) when GatewayTLSCrossNamespace.
+	GatewayTLSSecretNamespace string
+	// GatewayTLSCrossNamespace is true when the TLS secret lives outside
+	// envoy-gateway-system, requiring a namespace on certificateRefs and a ReferenceGrant.
+	GatewayTLSCrossNamespace bool
+
 	// MetalLB configuration (for local provider)
 	MetalLBAddressRange string
 
@@ -107,22 +120,24 @@ func NewTemplateData(cfg *config.NebariConfig, gitConfig *git.Config, settings p
 	}
 
 	// Set certificate configuration
-	if cfg.Certificate != nil {
-		if cfg.Certificate.Type == "letsencrypt" {
-			data.CertificateIssuer = "letsencrypt-issuer"
-			if cfg.Certificate.ACME != nil {
-				data.ACMEEmail = cfg.Certificate.ACME.Email
-				data.ACMEServer = cfg.Certificate.ACME.Server
-				if data.ACMEServer == "" {
-					data.ACMEServer = "https://acme-v02.api.letsencrypt.org/directory"
-				}
+	if cfg.Certificate != nil && cfg.Certificate.Type == config.CertificateTypeLetsEncrypt {
+		data.CertificateIssuer = "letsencrypt-issuer"
+		if cfg.Certificate.ACME != nil {
+			data.ACMEEmail = cfg.Certificate.ACME.Email
+			data.ACMEServer = cfg.Certificate.ACME.Server
+			if data.ACMEServer == "" {
+				data.ACMEServer = "https://acme-v02.api.letsencrypt.org/directory"
 			}
-		} else {
-			data.CertificateIssuer = certificateIssuerSelfSigned
 		}
 	} else {
 		data.CertificateIssuer = certificateIssuerSelfSigned
 	}
+
+	// Resolve the gateway TLS secret reference. The methods are nil-safe, so
+	// they return sensible defaults when no certificate block is configured.
+	data.UseExistingCertificate = cfg.Certificate != nil && cfg.Certificate.Type == config.CertificateTypeExisting
+	data.GatewayTLSSecretName, data.GatewayTLSSecretNamespace = cfg.Certificate.GatewaySecretRef()
+	data.GatewayTLSCrossNamespace = cfg.Certificate.IsCrossNamespaceSecret()
 
 	// Default domain if not set
 	if data.Domain == "" {
@@ -292,6 +307,11 @@ func WriteAllToGit(ctx context.Context, gitClient git.Client, cfg *config.Nebari
 			return nil
 		}
 
+		// Skip certificate templates that don't apply to the configured cert source.
+		if !d.IsDir() && skipCertificateTemplate(relPath, data) {
+			return nil
+		}
+
 		destPath := filepath.Join(workDir, relPath)
 
 		if d.IsDir() {
@@ -337,6 +357,33 @@ func isMetalLBPath(relPath string) bool {
 	return relPath == "apps/metallb.yaml" ||
 		relPath == "apps/metallb-config.yaml" ||
 		strings.HasPrefix(relPath, "manifests/metallb")
+}
+
+const (
+	gatewayCertificatePath    = "manifests/security/certificates/gateway-certificate.yaml"
+	certificatesAppPath       = "apps/certificates.yaml"
+	gatewayReferenceGrantPath = "manifests/networking/gateway-tls-referencegrant.yaml"
+)
+
+// skipCertificateTemplate reports whether a cert-related template should be
+// omitted for the configured certificate source. The cert-manager Certificate
+// (and its Argo CD Application) is only rendered for cert-manager-issued certs
+// (selfsigned/letsencrypt); the ReferenceGrant is only rendered for a
+// cross-namespace existing secret.
+//
+// The certificates Application is skipped alongside the Certificate because the
+// gateway cert is the only resource in manifests/security/certificates. Leaving
+// the Application would point it at an empty directory (allowEmpty: false) and
+// it would report as failed.
+func skipCertificateTemplate(relPath string, data TemplateData) bool {
+	switch relPath {
+	case gatewayCertificatePath, certificatesAppPath:
+		return data.UseExistingCertificate
+	case gatewayReferenceGrantPath:
+		return !data.GatewayTLSCrossNamespace
+	default:
+		return false
+	}
 }
 
 // processTemplate processes a template file with the given data.

--- a/pkg/config/certificate_test.go
+++ b/pkg/config/certificate_test.go
@@ -1,0 +1,307 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCertificateConfigValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         *CertificateConfig
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "nil receiver is valid",
+			cfg:  nil,
+		},
+		{
+			name: "empty type is valid",
+			cfg:  &CertificateConfig{},
+		},
+		{
+			name: "selfsigned is valid",
+			cfg:  &CertificateConfig{Type: "selfsigned"},
+		},
+		{
+			name: "letsencrypt is valid",
+			cfg:  &CertificateConfig{Type: "letsencrypt", ACME: &ACMEConfig{Email: "a@b.com"}},
+		},
+		{
+			name:        "unknown type rejected",
+			cfg:         &CertificateConfig{Type: "bogus"},
+			wantErr:     true,
+			errContains: "invalid certificate type",
+		},
+		{
+			name:        "existing with no source rejected",
+			cfg:         &CertificateConfig{Type: "existing"},
+			wantErr:     true,
+			errContains: "exactly one of",
+		},
+		{
+			name: "existing with multiple sources rejected",
+			cfg: &CertificateConfig{
+				Type:           "existing",
+				ExistingSecret: &ExistingSecretRef{Name: "my-tls"},
+				Files:          &CertFiles{CertFile: "/c", KeyFile: "/k"},
+			},
+			wantErr:     true,
+			errContains: "exactly one of",
+		},
+		{
+			name: "existing_secret without name rejected",
+			cfg: &CertificateConfig{
+				Type:           "existing",
+				ExistingSecret: &ExistingSecretRef{},
+			},
+			wantErr:     true,
+			errContains: "existing_secret.name",
+		},
+		{
+			name: "existing_secret with name is valid",
+			cfg: &CertificateConfig{
+				Type:           "existing",
+				ExistingSecret: &ExistingSecretRef{Name: "my-tls"},
+			},
+		},
+		{
+			name: "existing_secret cross-namespace is valid",
+			cfg: &CertificateConfig{
+				Type:           "existing",
+				ExistingSecret: &ExistingSecretRef{Name: "my-tls", Namespace: "my-ns"},
+			},
+		},
+		{
+			name: "files missing key_file rejected",
+			cfg: &CertificateConfig{
+				Type:  "existing",
+				Files: &CertFiles{CertFile: "/path/tls.crt"},
+			},
+			wantErr:     true,
+			errContains: "files requires both",
+		},
+		{
+			name: "files missing cert_file rejected",
+			cfg: &CertificateConfig{
+				Type:  "existing",
+				Files: &CertFiles{KeyFile: "/path/tls.key"},
+			},
+			wantErr:     true,
+			errContains: "files requires both",
+		},
+		{
+			name: "files with both is valid",
+			cfg: &CertificateConfig{
+				Type:  "existing",
+				Files: &CertFiles{CertFile: "/path/tls.crt", KeyFile: "/path/tls.key"},
+			},
+		},
+		{
+			name: "env missing key_env rejected",
+			cfg: &CertificateConfig{
+				Type: "existing",
+				Env:  &CertEnv{CertEnv: "NEBARI_TLS_CERT"},
+			},
+			wantErr:     true,
+			errContains: "env requires both",
+		},
+		{
+			name: "env with both is valid",
+			cfg: &CertificateConfig{
+				Type: "existing",
+				Env:  &CertEnv{CertEnv: "NEBARI_TLS_CERT", KeyEnv: "NEBARI_TLS_KEY"},
+			},
+		},
+		{
+			name: "secret_name combined with existing_secret rejected",
+			cfg: &CertificateConfig{
+				Type:           "existing",
+				SecretName:     "custom-tls",
+				ExistingSecret: &ExistingSecretRef{Name: "user-tls"},
+			},
+			wantErr:     true,
+			errContains: "secret_name",
+		},
+		{
+			name: "secret_name with files is valid",
+			cfg: &CertificateConfig{
+				Type:       "existing",
+				SecretName: "custom-tls",
+				Files:      &CertFiles{CertFile: "/c", KeyFile: "/k"},
+			},
+		},
+		{
+			name: "acme combined with existing rejected",
+			cfg: &CertificateConfig{
+				Type:           "existing",
+				ExistingSecret: &ExistingSecretRef{Name: "my-tls"},
+				ACME:           &ACMEConfig{Email: "a@b.com"},
+			},
+			wantErr:     true,
+			errContains: "acme",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Validate() = nil, want error containing %q", tt.errContains)
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("Validate() error = %q, want it to contain %q", err.Error(), tt.errContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Validate() = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestCertificateConfigParsing(t *testing.T) {
+	yaml := []byte(`
+project_name: test
+cluster:
+  aws:
+    region: us-west-2
+certificate:
+  type: existing
+  secret_name: my-gateway-tls
+  existing_secret:
+    name: user-tls
+    namespace: user-ns
+`)
+	cfg, err := ParseConfigBytes(yaml)
+	if err != nil {
+		t.Fatalf("ParseConfigBytes() error: %v", err)
+	}
+	if cfg.Certificate == nil {
+		t.Fatal("Certificate is nil")
+	}
+	if cfg.Certificate.Type != "existing" {
+		t.Errorf("Type = %q, want existing", cfg.Certificate.Type)
+	}
+	if cfg.Certificate.SecretName != "my-gateway-tls" {
+		t.Errorf("SecretName = %q, want my-gateway-tls", cfg.Certificate.SecretName)
+	}
+	if cfg.Certificate.ExistingSecret == nil {
+		t.Fatal("ExistingSecret is nil")
+	}
+	if cfg.Certificate.ExistingSecret.Name != "user-tls" {
+		t.Errorf("ExistingSecret.Name = %q, want user-tls", cfg.Certificate.ExistingSecret.Name)
+	}
+	if cfg.Certificate.ExistingSecret.Namespace != "user-ns" {
+		t.Errorf("ExistingSecret.Namespace = %q, want user-ns", cfg.Certificate.ExistingSecret.Namespace)
+	}
+}
+
+func TestCertificateConfigParsingFilesAndEnv(t *testing.T) {
+	yaml := []byte(`
+project_name: test
+cluster:
+  aws:
+    region: us-west-2
+certificate:
+  type: existing
+  files:
+    cert_file: /path/to/tls.crt
+    key_file: /path/to/tls.key
+`)
+	cfg, err := ParseConfigBytes(yaml)
+	if err != nil {
+		t.Fatalf("ParseConfigBytes() error: %v", err)
+	}
+	if cfg.Certificate.Files == nil {
+		t.Fatal("Files is nil")
+	}
+	if cfg.Certificate.Files.CertFile != "/path/to/tls.crt" {
+		t.Errorf("CertFile = %q", cfg.Certificate.Files.CertFile)
+	}
+	if cfg.Certificate.Files.KeyFile != "/path/to/tls.key" {
+		t.Errorf("KeyFile = %q", cfg.Certificate.Files.KeyFile)
+	}
+}
+
+func TestCertificateConfigResolvedSecretName(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *CertificateConfig
+		want string
+	}{
+		{name: "nil defaults", cfg: nil, want: "nebari-gateway-tls"},
+		{name: "empty defaults", cfg: &CertificateConfig{}, want: "nebari-gateway-tls"},
+		{name: "override", cfg: &CertificateConfig{SecretName: "custom-tls"}, want: "custom-tls"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.ResolvedSecretName(); got != tt.want {
+				t.Errorf("ResolvedSecretName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCertificateConfigGatewaySecretRef(t *testing.T) {
+	tests := []struct {
+		name          string
+		cfg           *CertificateConfig
+		wantName      string
+		wantNamespace string
+		wantCrossNS   bool
+	}{
+		{
+			name:          "nil uses defaults",
+			cfg:           nil,
+			wantName:      "nebari-gateway-tls",
+			wantNamespace: "envoy-gateway-system",
+			wantCrossNS:   false,
+		},
+		{
+			name:          "files source uses resolved secret name in default ns",
+			cfg:           &CertificateConfig{Type: "existing", Files: &CertFiles{CertFile: "/c", KeyFile: "/k"}},
+			wantName:      "nebari-gateway-tls",
+			wantNamespace: "envoy-gateway-system",
+			wantCrossNS:   false,
+		},
+		{
+			name:          "files source honors custom secret name",
+			cfg:           &CertificateConfig{Type: "existing", SecretName: "my-tls", Files: &CertFiles{CertFile: "/c", KeyFile: "/k"}},
+			wantName:      "my-tls",
+			wantNamespace: "envoy-gateway-system",
+			wantCrossNS:   false,
+		},
+		{
+			name:          "existing_secret same namespace",
+			cfg:           &CertificateConfig{Type: "existing", ExistingSecret: &ExistingSecretRef{Name: "user-tls"}},
+			wantName:      "user-tls",
+			wantNamespace: "envoy-gateway-system",
+			wantCrossNS:   false,
+		},
+		{
+			name:          "existing_secret cross namespace",
+			cfg:           &CertificateConfig{Type: "existing", ExistingSecret: &ExistingSecretRef{Name: "user-tls", Namespace: "user-ns"}},
+			wantName:      "user-tls",
+			wantNamespace: "user-ns",
+			wantCrossNS:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, namespace := tt.cfg.GatewaySecretRef()
+			if name != tt.wantName {
+				t.Errorf("name = %q, want %q", name, tt.wantName)
+			}
+			if namespace != tt.wantNamespace {
+				t.Errorf("namespace = %q, want %q", namespace, tt.wantNamespace)
+			}
+			if got := tt.cfg.IsCrossNamespaceSecret(); got != tt.wantCrossNS {
+				t.Errorf("IsCrossNamespaceSecret() = %v, want %v", got, tt.wantCrossNS)
+			}
+		})
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -156,13 +156,153 @@ func (c *ClusterConfig) ProviderConfig() map[string]any {
 	return nil
 }
 
+// Certificate type values accepted in CertificateConfig.Type.
+const (
+	// CertificateTypeSelfSigned mints a cert via cert-manager's self-signed ClusterIssuer.
+	CertificateTypeSelfSigned = "selfsigned"
+	// CertificateTypeLetsEncrypt mints a cert via cert-manager's ACME (Let's Encrypt) ClusterIssuer.
+	CertificateTypeLetsEncrypt = "letsencrypt"
+	// CertificateTypeExisting uses a user-supplied TLS certificate instead of cert-manager.
+	CertificateTypeExisting = "existing"
+
+	// DefaultGatewayTLSSecretName is the default name of the TLS secret the gateway references.
+	// The cert is the gateway's, shared across argocd / keycloak / the apex domain.
+	DefaultGatewayTLSSecretName = "nebari-gateway-tls"
+	// DefaultGatewayTLSNamespace is the namespace the gateway expects its TLS secret in.
+	DefaultGatewayTLSNamespace = "envoy-gateway-system"
+)
+
 // CertificateConfig holds TLS certificate configuration
 type CertificateConfig struct {
-	// Type is the certificate type: "selfsigned" or "letsencrypt"
+	// Type is the certificate type: "selfsigned", "letsencrypt", or "existing"
 	Type string `yaml:"type,omitempty"`
 
 	// ACME configuration for Let's Encrypt
 	ACME *ACMEConfig `yaml:"acme,omitempty"`
+
+	// SecretName overrides the name of the TLS secret the gateway references.
+	// Defaults to "nebari-gateway-tls". For type=existing with existing_secret,
+	// the gateway references ExistingSecret.Name instead.
+	SecretName string `yaml:"secret_name,omitempty"`
+
+	// ExistingSecret references a kubernetes.io/tls secret the user already created.
+	// Mutually exclusive with Files and Env. Only valid when Type=existing.
+	ExistingSecret *ExistingSecretRef `yaml:"existing_secret,omitempty"`
+
+	// Files reads PEM material from disk; NIC creates the secret directly.
+	// Mutually exclusive with ExistingSecret and Env. Only valid when Type=existing.
+	Files *CertFiles `yaml:"files,omitempty"`
+
+	// Env reads raw PEM material from environment variables; NIC creates the secret directly.
+	// Mutually exclusive with ExistingSecret and Files. Only valid when Type=existing.
+	Env *CertEnv `yaml:"env,omitempty"`
+}
+
+// ExistingSecretRef references a pre-existing TLS secret.
+type ExistingSecretRef struct {
+	// Name is the secret name (required).
+	Name string `yaml:"name"`
+	// Namespace is the secret's namespace. Defaults to envoy-gateway-system.
+	Namespace string `yaml:"namespace,omitempty"`
+}
+
+// CertFiles points at PEM cert/key files on disk.
+type CertFiles struct {
+	CertFile string `yaml:"cert_file"`
+	KeyFile  string `yaml:"key_file"`
+}
+
+// CertEnv names environment variables holding raw (non-base64) PEM material.
+type CertEnv struct {
+	CertEnv string `yaml:"cert_env"`
+	KeyEnv  string `yaml:"key_env"`
+}
+
+// Validate checks the certificate configuration. A nil receiver is valid
+// (no certificate block configured).
+func (c *CertificateConfig) Validate() error {
+	if c == nil {
+		return nil
+	}
+	switch c.Type {
+	case "", CertificateTypeSelfSigned, CertificateTypeLetsEncrypt:
+		return nil
+	case CertificateTypeExisting:
+		return c.validateExisting()
+	default:
+		return fmt.Errorf("invalid certificate type %q, must be one of: %s, %s, %s",
+			c.Type, CertificateTypeSelfSigned, CertificateTypeLetsEncrypt, CertificateTypeExisting)
+	}
+}
+
+// validateExisting validates the type=existing variant: exactly one source,
+// complete file/env pairs, and no ACME combination.
+func (c *CertificateConfig) validateExisting() error {
+	if c.ACME != nil {
+		return fmt.Errorf("certificate.acme cannot be combined with type=existing")
+	}
+
+	sources := 0
+	if c.ExistingSecret != nil {
+		sources++
+	}
+	if c.Files != nil {
+		sources++
+	}
+	if c.Env != nil {
+		sources++
+	}
+	if sources != 1 {
+		return fmt.Errorf("certificate type=existing requires exactly one of existing_secret, files, or env (found %d)", sources)
+	}
+
+	if c.ExistingSecret != nil {
+		if c.ExistingSecret.Name == "" {
+			return fmt.Errorf("certificate.existing_secret.name is required")
+		}
+		if c.SecretName != "" {
+			return fmt.Errorf("certificate.secret_name cannot be combined with existing_secret (the gateway references existing_secret.name directly)")
+		}
+	}
+	if c.Files != nil && (c.Files.CertFile == "" || c.Files.KeyFile == "") {
+		return fmt.Errorf("certificate.files requires both cert_file and key_file")
+	}
+	if c.Env != nil && (c.Env.CertEnv == "" || c.Env.KeyEnv == "") {
+		return fmt.Errorf("certificate.env requires both cert_env and key_env")
+	}
+	return nil
+}
+
+// ResolvedSecretName returns the name of the TLS secret NIC creates (files/env
+// sources) or, for selfsigned/letsencrypt, the cert-manager secret name.
+// Defaults to DefaultGatewayTLSSecretName.
+func (c *CertificateConfig) ResolvedSecretName() string {
+	if c != nil && c.SecretName != "" {
+		return c.SecretName
+	}
+	return DefaultGatewayTLSSecretName
+}
+
+// GatewaySecretRef returns the (name, namespace) the gateway listener should
+// reference. For existing_secret it points at the user's secret; otherwise it
+// is ResolvedSecretName in DefaultGatewayTLSNamespace.
+func (c *CertificateConfig) GatewaySecretRef() (name, namespace string) {
+	namespace = DefaultGatewayTLSNamespace
+	name = c.ResolvedSecretName()
+	if c != nil && c.Type == CertificateTypeExisting && c.ExistingSecret != nil {
+		name = c.ExistingSecret.Name
+		if c.ExistingSecret.Namespace != "" {
+			namespace = c.ExistingSecret.Namespace
+		}
+	}
+	return name, namespace
+}
+
+// IsCrossNamespaceSecret reports whether the gateway references a TLS secret in
+// a namespace other than DefaultGatewayTLSNamespace, which requires a ReferenceGrant.
+func (c *CertificateConfig) IsCrossNamespaceSecret() bool {
+	_, namespace := c.GatewaySecretRef()
+	return namespace != DefaultGatewayTLSNamespace
 }
 
 // ACMEConfig holds ACME (Let's Encrypt) configuration
@@ -207,6 +347,10 @@ func (c *NebariConfig) Validate(opts ValidateOptions) error {
 		if err := c.GitRepository.Validate(); err != nil {
 			return fmt.Errorf("invalid git_repository: %w", err)
 		}
+	}
+
+	if err := c.Certificate.Validate(); err != nil {
+		return fmt.Errorf("invalid certificate: %w", err)
 	}
 
 	return nil

--- a/pkg/nic/deploy.go
+++ b/pkg/nic/deploy.go
@@ -94,6 +94,15 @@ func (c *Client) Deploy(ctx context.Context, cfg *config.NebariConfig, opts Depl
 		WithMetadata("provider", cfg.Cluster.ProviderName()).
 		WithMetadata("project_name", cfg.ProjectName))
 
+	// For user-supplied certificates sourced from files/env, validate the
+	// material is readable and a valid keypair before provisioning anything.
+	// This turns a local config error into a fast failure instead of a silently
+	// broken gateway discovered after the cluster is up.
+	if err := argocd.PreflightGatewayTLS(cfg); err != nil {
+		span.RecordError(err)
+		return nil, fmt.Errorf("gateway TLS certificate: %w", err)
+	}
+
 	if opts.Timeout > 0 {
 		span.SetAttributes(attribute.String("timeout", opts.Timeout.String()))
 		status.Send(ctx, status.NewUpdate(status.LevelInfo, "Using custom timeout").


### PR DESCRIPTION
## Summary

Closes https://github.com/nebari-dev/nebari-infrastructure-core/issues/333

Allow operators to supply their own TLS certificate for the Nebari gateway instead of having cert-manager mint one via the self-signed/Let's Encrypt `ClusterIssuer`.

Adds `certificate.type: existing` with three mutually-exclusive sources:

| Source | Behavior |
|--------|----------|
| `existing_secret` | References a `kubernetes.io/tls` secret the user manages. When it lives outside `envoy-gateway-system`, NIC sets the `certificateRefs` namespace **and** renders a Gateway-API `ReferenceGrant`. |
| `files` | NIC reads PEM cert/key from disk and creates the secret directly in `envoy-gateway-system`. |
| `env` | NIC reads raw (non-base64) PEM from env vars and creates the secret directly. |

For `files`/`env` the material is written **only** to the cluster secret — never to the GitOps repo. Cert/key bytes are never logged or recorded in OpenTelemetry span attributes.

## Behavior details

- **Validation** rejects: missing source, more than one source, partial `files`/`env` pairs, `existing_secret` without a name, `secret_name` combined with `existing_secret`, and `acme` combined with `type=existing`.
- **cert-manager skipped**: when `type=existing`, both `gateway-certificate.yaml` and its Argo CD `certificates` Application are skipped (the app would otherwise sync an empty directory under `allowEmpty: false`).
- **SAN check**: NIC parses the resolved cert and **warns (does not fail)** when `<domain>`, `keycloak.<domain>`, or `argocd.<domain>` is missing from the SANs. Wildcard + apex is honored.
- **Fail-fast pre-flight**: `files`/`env` material is validated (readable + valid keypair) at deploy start, before any cloud provisioning, so a bad path or mismatched keypair fails fast instead of producing a silently broken gateway.

## Testing

- New table-driven unit tests in `pkg/config` and `pkg/argocd` cover parsing, every validation rejection, same-ns/cross-ns cases, file source, env source, idempotency, the cert-manager/app skip, and the SAN warning (including wildcard coverage).
- `make check` passes (fmt, vet, lint, race + coverage tests).
- Verified end-to-end through the real CLI: the example config validates, and ambiguous configs are rejected.

## Docs & example

- `docs/custom-tls-certificate.md` — SAN requirements, the three sources, `kubectl` secret creation, config snippets, the cross-namespace + `ReferenceGrant` case (with the namespace prerequisite), and a troubleshooting table.
- `examples/custom-tls-config.yaml` — annotated working config.

## Not covered here

The issue's manual on-cluster verification (deploy each source, hit `argocd.<domain>`/`keycloak.<domain>` in a browser, confirm the served cert) requires a live cluster.