### PR TITLE
Fix bad import after providers refactor

### DIFF
--- a/pkg/argocd/certificate_test.go
+++ b/pkg/argocd/certificate_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 
 	"github.com/nebari-dev/nebari-infrastructure-core/pkg/config"
-	"github.com/nebari-dev/nebari-infrastructure-core/pkg/provider"
+	"github.com/nebari-dev/nebari-infrastructure-core/pkg/providers/cluster"
 )
 
 func TestNewTemplateData_Certificate(t *testing.T) {
-	settings := provider.InfraSettings{}
+	settings := cluster.InfraSettings{}
 
 	tests := []struct {
 		name              string
@@ -181,7 +181,7 @@ func TestWriteAllToGit_SkipsCertManagerForExisting(t *testing.T) {
 		},
 	}
 	mock := &mockGitClient{workDir: tmpDir}
-	if err := WriteAllToGit(ctx, mock, cfg, nil, provider.InfraSettings{}); err != nil {
+	if err := WriteAllToGit(ctx, mock, cfg, nil, cluster.InfraSettings{}); err != nil {
 		t.Fatalf("WriteAllToGit() error: %v", err)
 	}
 
@@ -210,7 +210,7 @@ func TestWriteAllToGit_RendersCertManagerForSelfSigned(t *testing.T) {
 
 	cfg := &config.NebariConfig{Domain: "test.example.com"}
 	mock := &mockGitClient{workDir: tmpDir}
-	if err := WriteAllToGit(ctx, mock, cfg, nil, provider.InfraSettings{}); err != nil {
+	if err := WriteAllToGit(ctx, mock, cfg, nil, cluster.InfraSettings{}); err != nil {
 		t.Fatalf("WriteAllToGit() error: %v", err)
 	}
 
@@ -236,7 +236,7 @@ func TestWriteAllToGit_RendersReferenceGrantCrossNamespace(t *testing.T) {
 		},
 	}
 	mock := &mockGitClient{workDir: tmpDir}
-	if err := WriteAllToGit(ctx, mock, cfg, nil, provider.InfraSettings{}); err != nil {
+	if err := WriteAllToGit(ctx, mock, cfg, nil, cluster.InfraSettings{}); err != nil {
 		t.Fatalf("WriteAllToGit() error: %v", err)
 	}
 


### PR DESCRIPTION
## Description

We recently merged https://github.com/nebari-dev/nebari-infrastructure-core/pull/404 and CI broke because of a bad import. See: https://github.com/nebari-dev/nebari-infrastructure-core/actions/runs/27960756369/job/82741302523#step:6:37

```
  Error: pkg/argocd/certificate_test.go:11:2: could not import github.com/nebari-dev/nebari-infrastructure-core/pkg/provider (pkg/argocd/certificate_test.go:11:2: no required module provides package github.com/nebari-dev/nebari-infrastructure-core/pkg/provider; to add it:
```

This happened because we also merged https://github.com/nebari-dev/nebari-infrastructure-core/pull/405 before, which moved `pkg/provider` to `pkg/providers/cluster`.

## How to Test

Verify CI checks