### PR TITLE
feat(aws): expose node group max_unavailable for Longhorn-aware rolling

### DIFF
--- a/docs/design-doc/appendix/16-configuration-reference.md
+++ b/docs/design-doc/appendix/16-configuration-reference.md
@@ -174,6 +174,13 @@ amazon_web_services:
       # Not recommended for critical workloads
       spot: false
 
+      # OPTIONAL: Max nodes to roll at once during an update
+      # Default: unset (the EKS managed node group default of 33% unavailable)
+      # Sets update_config.max_unavailable on the node group. Set to 1 on a
+      # Longhorn storage pool so replicas rebuild onto the replacement node
+      # before the next old node is drained, avoiding faulted volumes.
+      max_unavailable: 1
+
     # User workload node group example
     user:
       instance: m5.xlarge

--- a/pkg/providers/cluster/aws/config.go
+++ b/pkg/providers/cluster/aws/config.go
@@ -169,15 +169,21 @@ func (c *Config) ClusterAutoscalerImageTag() string {
 }
 
 type NodeGroup struct {
-	Instance string            `yaml:"instance" json:"instance"`
-	MinNodes int               `yaml:"min_nodes,omitempty" json:"min_nodes"`
-	MaxNodes int               `yaml:"max_nodes,omitempty" json:"max_nodes"`
-	GPU      bool              `yaml:"gpu,omitempty" json:"-"`
-	AMIType  *string           `yaml:"ami_type,omitempty" json:"ami_type,omitempty"`
-	Spot     bool              `yaml:"spot,omitempty" json:"spot"`
-	DiskSize *int              `yaml:"disk_size,omitempty" json:"disk_size,omitempty"`
-	Labels   map[string]string `yaml:"labels,omitempty" json:"labels,omitempty"`
-	Taints   []Taint           `yaml:"taints,omitempty" json:"taints,omitempty"`
+	Instance string  `yaml:"instance" json:"instance"`
+	MinNodes int     `yaml:"min_nodes,omitempty" json:"min_nodes"`
+	MaxNodes int     `yaml:"max_nodes,omitempty" json:"max_nodes"`
+	GPU      bool    `yaml:"gpu,omitempty" json:"-"`
+	AMIType  *string `yaml:"ami_type,omitempty" json:"ami_type,omitempty"`
+	Spot     bool    `yaml:"spot,omitempty" json:"spot"`
+	DiskSize *int    `yaml:"disk_size,omitempty" json:"disk_size,omitempty"`
+	// MaxUnavailable caps how many nodes a rolling update takes down at once
+	// (rendered as the EKS managed node group update_config.max_unavailable).
+	// nil leaves the upstream module default (33% unavailable) in place. Set to
+	// 1 on a Longhorn storage pool so replicas rebuild onto the replacement node
+	// before the next old node is drained.
+	MaxUnavailable *int              `yaml:"max_unavailable,omitempty" json:"max_unavailable,omitempty"`
+	Labels         map[string]string `yaml:"labels,omitempty" json:"labels,omitempty"`
+	Taints         []Taint           `yaml:"taints,omitempty" json:"taints,omitempty"`
 }
 
 type Taint struct {

--- a/pkg/providers/cluster/aws/config_test.go
+++ b/pkg/providers/cluster/aws/config_test.go
@@ -10,6 +10,8 @@ import (
 
 func boolPtr(b bool) *bool { return &b }
 
+func intPtr(i int) *int { return &i }
+
 func durPtr(d time.Duration) *time.Duration { return &d }
 
 func TestLonghornEnabled(t *testing.T) {

--- a/pkg/providers/cluster/aws/templates/main.tf
+++ b/pkg/providers/cluster/aws/templates/main.tf
@@ -1,7 +1,7 @@
 module "eks_cluster" {
   source  = "nebari-dev/eks-cluster/aws"
-  version = "0.6.0"
-  
+  version = "0.7.0"
+
   project_name                             = var.project_name
   tags                                     = var.tags
   availability_zones                       = var.availability_zones

--- a/pkg/providers/cluster/aws/tofu_test.go
+++ b/pkg/providers/cluster/aws/tofu_test.go
@@ -509,3 +509,51 @@ func TestToTFVarsLonghornDiskLabel(t *testing.T) {
 		}
 	})
 }
+
+func TestToTFVarsNodeGroupMaxUnavailable(t *testing.T) {
+	tests := []struct {
+		name    string
+		group   NodeGroup
+		wantSet bool
+		wantVal int
+	}{
+		{
+			name:    "max_unavailable set flows through to tfvars",
+			group:   NodeGroup{Instance: "m7g.large", MaxUnavailable: intPtr(1)},
+			wantSet: true,
+			wantVal: 1,
+		},
+		{
+			name:    "max_unavailable unset stays nil (module default preserved)",
+			group:   NodeGroup{Instance: "m7g.large"},
+			wantSet: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{
+				Region:            "us-west-2",
+				KubernetesVersion: "1.33",
+				NodeGroups:        map[string]NodeGroup{"storage": tt.group},
+			}
+
+			vars, err := cfg.toTFVars("test-project")
+			if err != nil {
+				t.Fatalf("toTFVars: %v", err)
+			}
+
+			got := vars.NodeGroups["storage"].MaxUnavailable
+			if tt.wantSet {
+				if got == nil {
+					t.Fatalf("MaxUnavailable = nil, want %d", tt.wantVal)
+				}
+				if *got != tt.wantVal {
+					t.Errorf("MaxUnavailable = %d, want %d", *got, tt.wantVal)
+				}
+			} else if got != nil {
+				t.Errorf("MaxUnavailable = %d, want nil", *got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
> Draft: blocked on the module change landing and releasing as v0.7.0.

Closes #415.

## What

Expose `max_unavailable` on AWS node groups in `config.yaml`:

```yaml
cluster:
  aws:
    node_groups:
      storage:
        instance: m7g.large
        max_unavailable: 1   # roll one storage node at a time
```

It threads through the NIC `NodeGroup` struct to the eks-cluster module (whose `node_groups` variable is `type = any`), which renders `update_config.max_unavailable` on the EKS managed node group. Leaving it unset preserves the upstream default (33% unavailable).

## Why

EKS managed node group updates already create new nodes before terminating old ones and drain respecting PodDisruptionBudgets, but they treat a new node as done at Kubernetes-`Ready`, not when Longhorn has rebuilt replicas onto it. Rolling more than one storage node at a time can fault volumes (see openteams-ai/mystic.openteams.ai#86 and #354).

Setting `max_unavailable: 1` on the dedicated storage pool, combined with Longhorn's instance-manager PDB plus `node-drain-policy: block-if-contains-last-replica` and `min_nodes >= replica_count + 1`, lets the replacement node come up and re-sync before the next old node is drained.

## Changes

- `pkg/providers/cluster/aws/config.go`: `MaxUnavailable *int` on `NodeGroup` (nil preserves the module default).
- `pkg/providers/cluster/aws/tofu_test.go`, `config_test.go`: table-driven test covering set (flows through) and unset (stays nil), written test-first.
- `pkg/providers/cluster/aws/templates/main.tf`: bump eks-cluster module pin to `0.7.0`.
- `docs/design-doc/appendix/16-configuration-reference.md`: document the field.

## Testing

- `go test ./...` passes; `go vet` clean; `golangci-lint` 0 issues; gofmt clean.

## Dependency / merge order

Requires the module support in nebari-dev/terraform-aws-eks-cluster#38, released as `v0.7.0`. The module pin in this PR is set to `0.7.0`; adjust if the release lands under a different version. Merge order: module PR -> release -> mark this ready -> merge.
