### PR TITLE
Fix Gitops file permissions and host path

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ The cluster is named after `project_name` (kube context `kind-<project_name>`) a
 
 **GitOps repository:**
 
-- Omit `git_repository` and NIC auto-creates and mounts a local repo at `/tmp/nebari-gitops-<project_name>` — zero configuration.
+- Omit `git_repository` and NIC auto-creates and mounts a local repo at `~/.nebari/gitops/<project_name>` — zero configuration.
 - For a remote repo, set `git_repository.url` to an SSH/HTTPS URL and supply credentials via the `GIT_SSH_PRIVATE_KEY` environment variable (or a token).
 - For a custom local `file://` path, you must also declare a matching `cluster.local.kind.extra_mounts` entry so the kind node can read it — see `examples/local-config.yaml`.
 

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ The cluster is named after `project_name` (kube context `kind-<project_name>`) a
 
 **GitOps repository:**
 
-- Omit `git_repository` and NIC auto-creates and mounts a local repo at `~/.nebari/gitops/<project_name>` — zero configuration.
+- Omit `git_repository` and NIC auto-creates and mounts a local repo at `~/.nic/gitops/<project_name>` — zero configuration.
 - For a remote repo, set `git_repository.url` to an SSH/HTTPS URL and supply credentials via the `GIT_SSH_PRIVATE_KEY` environment variable (or a token).
 - For a custom local `file://` path, you must also declare a matching `cluster.local.kind.extra_mounts` entry so the kind node can read it — see `examples/local-config.yaml`.
 

--- a/docs/local-kind-development.md
+++ b/docs/local-kind-development.md
@@ -24,7 +24,7 @@ The Makefile reads `examples/local-config.yaml` and automatically handles three 
 
 | Config | What happens |
 |--------|-------------|
-| No `git_repository` section | Auto-creates `~/.nebari/gitops/{project_name}` and mounts it into the cluster |
+| No `git_repository` section | Auto-creates `~/.nic/gitops/{project_name}` and mounts it into the cluster |
 | `url: "file:///path/to/repo"` | Mounts that local path into the cluster |
 | `url: "git@github.com:..."` | No mount — ArgoCD pulls from the remote repo directly |
 

--- a/docs/local-kind-development.md
+++ b/docs/local-kind-development.md
@@ -24,11 +24,13 @@ The Makefile reads `examples/local-config.yaml` and automatically handles three 
 
 | Config | What happens |
 |--------|-------------|
-| No `git_repository` section | Auto-creates `/tmp/nebari-gitops-{project_name}` and mounts it into the cluster |
+| No `git_repository` section | Auto-creates `~/.nebari/gitops/{project_name}` and mounts it into the cluster |
 | `url: "file:///path/to/repo"` | Mounts that local path into the cluster |
 | `url: "git@github.com:..."` | No mount — ArgoCD pulls from the remote repo directly |
 
 For local `file://` repos, the path is mounted into both the Kind node and the ArgoCD repo-server pod so ArgoCD can read manifests directly from your filesystem.
+
+If an existing Kind cluster was created with a different local GitOps path, recreate it with `make localkind-down` followed by `make localkind-up`; Kind mounts are fixed at cluster creation time.
 
 > **Note:** `file://` repos only work when the cluster nodes can access the local path (Kind, k3s, bare metal). For cloud providers (AWS, GCP, Azure), use a remote git repository since Kubernetes nodes don't have access to your local filesystem.
 

--- a/docs/local-kind-development.md
+++ b/docs/local-kind-development.md
@@ -25,10 +25,12 @@ The Makefile reads `examples/local-config.yaml` and automatically handles three 
 | Config | What happens |
 |--------|-------------|
 | No `git_repository` section | Auto-creates `~/.nic/gitops/{project_name}` and mounts it into the cluster |
-| `url: "file:///path/to/repo"` | Mounts that local path into the cluster |
+| `url: "file:///path/to/repo"` | Uses the matching `cluster.local.kind.extra_mounts` entry supplied by the user |
 | `url: "git@github.com:..."` | No mount — ArgoCD pulls from the remote repo directly |
 
 For local `file://` repos, the path is mounted into both the Kind node and the ArgoCD repo-server pod so ArgoCD can read manifests directly from your filesystem.
+
+NIC normalizes local GitOps repositories to directory mode `0755` and file mode `0644` so the non-root ArgoCD repo-server can read them. Other `extra_mounts` are user-managed, and NIC does not recursively change their permissions.
 
 If an existing Kind cluster was created with a different local GitOps path, recreate it with `make localkind-down` followed by `make localkind-up`; Kind mounts are fixed at cluster creation time.
 

--- a/examples/local-config.yaml
+++ b/examples/local-config.yaml
@@ -41,7 +41,7 @@ cluster:
 # Configures the repository that ArgoCD will use to manage cluster resources
 #
 # OPTION 1: Auto-generated local directory (zero configuration for development)
-# Simply omit the git_repository section and NIC will auto-create /tmp/nebari-gitops-{project_name}
+# Simply omit the git_repository section and NIC will auto-create ~/.nebari/gitops/{project_name}
 # and mount it on the kind cluster
 #
 # OPTION 2: Explicit local directory (custom location)

--- a/examples/local-config.yaml
+++ b/examples/local-config.yaml
@@ -41,7 +41,7 @@ cluster:
 # Configures the repository that ArgoCD will use to manage cluster resources
 #
 # OPTION 1: Auto-generated local directory (zero configuration for development)
-# Simply omit the git_repository section and NIC will auto-create ~/.nebari/gitops/{project_name}
+# Simply omit the git_repository section and NIC will auto-create ~/.nic/gitops/{project_name}
 # and mount it on the kind cluster
 #
 # OPTION 2: Explicit local directory (custom location)

--- a/examples/local-config.yaml
+++ b/examples/local-config.yaml
@@ -49,7 +49,8 @@ cluster:
 # cluster.local.kind.extra_mounts entry for the same path (see the kind block
 # above). NIC only auto-mounts the OPTION 1 default, so a custom file:// path is
 # invisible to the in-cluster ArgoCD repo-server unless you mount it yourself.
-# The paths must match exactly.
+# The paths must match exactly. NIC normalizes the configured GitOps repository
+# so the non-root repo-server can read it; unrelated extra_mounts are unchanged.
 # git_repository:
 #   url: "file:///home/user/my-gitops-repo"   # must be an absolute path
 #   branch: main

--- a/pkg/argocd/writer.go
+++ b/pkg/argocd/writer.go
@@ -360,9 +360,6 @@ func WriteAllToGit(ctx context.Context, gitClient git.Client, cfg *config.Nebari
 		if err := os.MkdirAll(filepath.Dir(destPath), git.LocalGitOpsDirMode); err != nil {
 			return fmt.Errorf("failed to create directory for %s: %w", destPath, err)
 		}
-		if err := os.Chmod(filepath.Dir(destPath), git.LocalGitOpsDirMode); err != nil {
-			return fmt.Errorf("failed to set directory permissions for %s: %w", destPath, err)
-		}
 
 		// Write processed content
 		if err := os.WriteFile(destPath, processed, git.LocalGitOpsFileMode); err != nil {

--- a/pkg/argocd/writer.go
+++ b/pkg/argocd/writer.go
@@ -338,10 +338,10 @@ func WriteAllToGit(ctx context.Context, gitClient git.Client, cfg *config.Nebari
 		destPath := filepath.Join(workDir, relPath)
 
 		if d.IsDir() {
-			if err := os.MkdirAll(destPath, git.LocalGitOpsDirMode); err != nil {
+			if err := os.MkdirAll(destPath, git.GitOpsDirMode); err != nil {
 				return err
 			}
-			return os.Chmod(destPath, git.LocalGitOpsDirMode)
+			return os.Chmod(destPath, git.GitOpsDirMode)
 		}
 
 		// Read template content
@@ -357,15 +357,15 @@ func WriteAllToGit(ctx context.Context, gitClient git.Client, cfg *config.Nebari
 		}
 
 		// Ensure parent directory exists
-		if err := os.MkdirAll(filepath.Dir(destPath), git.LocalGitOpsDirMode); err != nil {
+		if err := os.MkdirAll(filepath.Dir(destPath), git.GitOpsDirMode); err != nil {
 			return fmt.Errorf("failed to create directory for %s: %w", destPath, err)
 		}
 
 		// Write processed content
-		if err := os.WriteFile(destPath, processed, git.LocalGitOpsFileMode); err != nil {
+		if err := os.WriteFile(destPath, processed, git.GitOpsFileMode); err != nil {
 			return fmt.Errorf("failed to write %s: %w", destPath, err)
 		}
-		if err := os.Chmod(destPath, git.LocalGitOpsFileMode); err != nil {
+		if err := os.Chmod(destPath, git.GitOpsFileMode); err != nil {
 			return fmt.Errorf("failed to set file permissions for %s: %w", destPath, err)
 		}
 

--- a/pkg/argocd/writer.go
+++ b/pkg/argocd/writer.go
@@ -315,8 +315,10 @@ func WriteAllToGit(ctx context.Context, gitClient git.Client, cfg *config.Nebari
 		destPath := filepath.Join(workDir, relPath)
 
 		if d.IsDir() {
-			// Create directory
-			return os.MkdirAll(destPath, 0750)
+			if err := os.MkdirAll(destPath, git.LocalGitOpsDirMode); err != nil { //nolint:gosec // Generated GitOps manifests must be pod-readable.
+				return err
+			}
+			return os.Chmod(destPath, git.LocalGitOpsDirMode) //nolint:gosec // Generated GitOps manifests must be pod-readable.
 		}
 
 		// Read template content
@@ -332,13 +334,19 @@ func WriteAllToGit(ctx context.Context, gitClient git.Client, cfg *config.Nebari
 		}
 
 		// Ensure parent directory exists
-		if err := os.MkdirAll(filepath.Dir(destPath), 0750); err != nil {
+		if err := os.MkdirAll(filepath.Dir(destPath), git.LocalGitOpsDirMode); err != nil { //nolint:gosec // Generated GitOps manifests must be pod-readable.
 			return fmt.Errorf("failed to create directory for %s: %w", destPath, err)
+		}
+		if err := os.Chmod(filepath.Dir(destPath), git.LocalGitOpsDirMode); err != nil { //nolint:gosec // Generated GitOps manifests must be pod-readable.
+			return fmt.Errorf("failed to set directory permissions for %s: %w", destPath, err)
 		}
 
 		// Write processed content
-		if err := os.WriteFile(destPath, processed, 0600); err != nil {
+		if err := os.WriteFile(destPath, processed, git.LocalGitOpsFileMode); err != nil { //nolint:gosec // Generated GitOps manifests are non-secret and must be pod-readable.
 			return fmt.Errorf("failed to write %s: %w", destPath, err)
+		}
+		if err := os.Chmod(destPath, git.LocalGitOpsFileMode); err != nil { //nolint:gosec // Generated GitOps manifests are non-secret and must be pod-readable.
+			return fmt.Errorf("failed to set file permissions for %s: %w", destPath, err)
 		}
 
 		return nil

--- a/pkg/argocd/writer.go
+++ b/pkg/argocd/writer.go
@@ -315,10 +315,10 @@ func WriteAllToGit(ctx context.Context, gitClient git.Client, cfg *config.Nebari
 		destPath := filepath.Join(workDir, relPath)
 
 		if d.IsDir() {
-			if err := os.MkdirAll(destPath, git.LocalGitOpsDirMode); err != nil { //nolint:gosec // Generated GitOps manifests must be pod-readable.
+			if err := os.MkdirAll(destPath, git.LocalGitOpsDirMode); err != nil {
 				return err
 			}
-			return os.Chmod(destPath, git.LocalGitOpsDirMode) //nolint:gosec // Generated GitOps manifests must be pod-readable.
+			return os.Chmod(destPath, git.LocalGitOpsDirMode)
 		}
 
 		// Read template content
@@ -334,18 +334,18 @@ func WriteAllToGit(ctx context.Context, gitClient git.Client, cfg *config.Nebari
 		}
 
 		// Ensure parent directory exists
-		if err := os.MkdirAll(filepath.Dir(destPath), git.LocalGitOpsDirMode); err != nil { //nolint:gosec // Generated GitOps manifests must be pod-readable.
+		if err := os.MkdirAll(filepath.Dir(destPath), git.LocalGitOpsDirMode); err != nil {
 			return fmt.Errorf("failed to create directory for %s: %w", destPath, err)
 		}
-		if err := os.Chmod(filepath.Dir(destPath), git.LocalGitOpsDirMode); err != nil { //nolint:gosec // Generated GitOps manifests must be pod-readable.
+		if err := os.Chmod(filepath.Dir(destPath), git.LocalGitOpsDirMode); err != nil {
 			return fmt.Errorf("failed to set directory permissions for %s: %w", destPath, err)
 		}
 
 		// Write processed content
-		if err := os.WriteFile(destPath, processed, git.LocalGitOpsFileMode); err != nil { //nolint:gosec // Generated GitOps manifests are non-secret and must be pod-readable.
+		if err := os.WriteFile(destPath, processed, git.LocalGitOpsFileMode); err != nil {
 			return fmt.Errorf("failed to write %s: %w", destPath, err)
 		}
-		if err := os.Chmod(destPath, git.LocalGitOpsFileMode); err != nil { //nolint:gosec // Generated GitOps manifests are non-secret and must be pod-readable.
+		if err := os.Chmod(destPath, git.LocalGitOpsFileMode); err != nil {
 			return fmt.Errorf("failed to set file permissions for %s: %w", destPath, err)
 		}
 

--- a/pkg/argocd/writer_test.go
+++ b/pkg/argocd/writer_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/nebari-dev/nebari-infrastructure-core/pkg/config"
+	"github.com/nebari-dev/nebari-infrastructure-core/pkg/git"
 	"github.com/nebari-dev/nebari-infrastructure-core/pkg/providers/cluster"
 )
 
@@ -628,8 +629,21 @@ func TestWriteAllToGit_IncludesRedirectRoute(t *testing.T) {
 	}
 
 	redirectPath := filepath.Join(tmpDir, "manifests", "networking", "routes", "http-to-https-redirect.yaml")
-	if _, err := os.Stat(redirectPath); os.IsNotExist(err) {
+	redirectInfo, err := os.Stat(redirectPath)
+	if os.IsNotExist(err) {
 		t.Error("WriteAllToGit did not write http-to-https-redirect.yaml")
+	} else if err != nil {
+		t.Fatalf("stat redirect route: %v", err)
+	} else if got := redirectInfo.Mode().Perm(); got != git.LocalGitOpsFileMode {
+		t.Errorf("redirect route mode = %v, want %v", got, git.LocalGitOpsFileMode)
+	}
+
+	routesInfo, err := os.Stat(filepath.Dir(redirectPath))
+	if err != nil {
+		t.Fatalf("stat routes directory: %v", err)
+	}
+	if got := routesInfo.Mode().Perm(); got != git.LocalGitOpsDirMode {
+		t.Errorf("routes directory mode = %v, want %v", got, git.LocalGitOpsDirMode)
 	}
 
 	content, err := os.ReadFile(redirectPath) //nolint:gosec // path is t.TempDir() + constant

--- a/pkg/argocd/writer_test.go
+++ b/pkg/argocd/writer_test.go
@@ -730,16 +730,16 @@ func TestWriteAllToGit_IncludesRedirectRoute(t *testing.T) {
 		t.Error("WriteAllToGit did not write http-to-https-redirect.yaml")
 	} else if err != nil {
 		t.Fatalf("stat redirect route: %v", err)
-	} else if got := redirectInfo.Mode().Perm(); got != git.LocalGitOpsFileMode {
-		t.Errorf("redirect route mode = %v, want %v", got, git.LocalGitOpsFileMode)
+	} else if got := redirectInfo.Mode().Perm(); got != git.GitOpsFileMode {
+		t.Errorf("redirect route mode = %v, want %v", got, git.GitOpsFileMode)
 	}
 
 	routesInfo, err := os.Stat(filepath.Dir(redirectPath))
 	if err != nil {
 		t.Fatalf("stat routes directory: %v", err)
 	}
-	if got := routesInfo.Mode().Perm(); got != git.LocalGitOpsDirMode {
-		t.Errorf("routes directory mode = %v, want %v", got, git.LocalGitOpsDirMode)
+	if got := routesInfo.Mode().Perm(); got != git.GitOpsDirMode {
+		t.Errorf("routes directory mode = %v, want %v", got, git.GitOpsDirMode)
 	}
 
 	content, err := os.ReadFile(redirectPath) //nolint:gosec // path is t.TempDir() + constant

--- a/pkg/git/client_impl.go
+++ b/pkg/git/client_impl.go
@@ -3,6 +3,7 @@ package git
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -263,6 +264,11 @@ func (c *ClientImpl) initLocalPath(ctx context.Context) error {
 	_, span := tracer.Start(ctx, "git.initLocalPath")
 	defer span.End()
 
+	if err := EnsureLocalGitOpsDir(ctx, c.repoPath); err != nil {
+		span.RecordError(err)
+		return err
+	}
+
 	// Ensure working directory exists
 	if c.cfg.Path != "" {
 		if err := os.MkdirAll(c.workDir, LocalGitOpsDirMode); err != nil {
@@ -395,6 +401,54 @@ func (c *ClientImpl) pull(ctx context.Context) error {
 // WorkDir returns the local working directory path.
 func (c *ClientImpl) WorkDir() string {
 	return c.workDir
+}
+
+// NormalizeLocalPermissions normalizes a local file:// GitOps repository tree,
+// including .git, so ArgoCD's non-root repo-server can read refs and generated
+// manifests through a read-only kind hostPath mount. Symlinks are skipped.
+func (c *ClientImpl) NormalizeLocalPermissions(ctx context.Context) error {
+	tracer := otel.Tracer(tracerName)
+	_, span := tracer.Start(ctx, "git.NormalizeLocalPermissions")
+	defer span.End()
+	span.SetAttributes(attribute.String("git.repo_path", c.repoPath))
+
+	if c.cfg == nil || !c.cfg.IsLocalPath() {
+		span.SetAttributes(attribute.Bool("git.local_path", false))
+		return nil
+	}
+	span.SetAttributes(attribute.Bool("git.local_path", true))
+
+	rootDir, err := os.OpenRoot(c.repoPath)
+	if err != nil {
+		span.RecordError(err)
+		return fmt.Errorf("open local gitops root %s: %w", c.repoPath, err)
+	}
+	defer func() {
+		_ = rootDir.Close()
+	}()
+
+	err = fs.WalkDir(rootDir.FS(), ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.Type()&fs.ModeSymlink != 0 {
+			return nil
+		}
+
+		mode := LocalGitOpsFileMode
+		if d.IsDir() {
+			mode = LocalGitOpsDirMode
+		}
+		if err := rootDir.Chmod(path, mode); err != nil {
+			return fmt.Errorf("set permissions on %s: %w", path, err)
+		}
+		return nil
+	})
+	if err != nil {
+		span.RecordError(err)
+		return fmt.Errorf("set local gitops permissions under %s: %w", c.repoPath, err)
+	}
+	return nil
 }
 
 // CommitAndPush stages all changes, commits, and pushes to remote.

--- a/pkg/git/client_impl.go
+++ b/pkg/git/client_impl.go
@@ -265,11 +265,11 @@ func (c *ClientImpl) initLocalPath(ctx context.Context) error {
 
 	// Ensure working directory exists
 	if c.cfg.Path != "" {
-		if err := os.MkdirAll(c.workDir, LocalGitOpsDirMode); err != nil { //nolint:gosec // Local GitOps path must be readable by ArgoCD's non-root repo-server.
+		if err := os.MkdirAll(c.workDir, LocalGitOpsDirMode); err != nil {
 			span.RecordError(err)
 			return fmt.Errorf("failed to create subdirectory %s: %w", c.cfg.Path, err)
 		}
-		if err := os.Chmod(c.workDir, LocalGitOpsDirMode); err != nil { //nolint:gosec // Local GitOps path must be readable by ArgoCD's non-root repo-server.
+		if err := os.Chmod(c.workDir, LocalGitOpsDirMode); err != nil {
 			span.RecordError(err)
 			return fmt.Errorf("failed to set subdirectory permissions %s: %w", c.cfg.Path, err)
 		}
@@ -538,11 +538,11 @@ func (c *ClientImpl) WriteBootstrapMarker(ctx context.Context) error {
 
 	content := fmt.Sprintf("bootstrapped_at: %s\n", time.Now().UTC().Format(time.RFC3339))
 
-	if err := os.WriteFile(markerPath, []byte(content), LocalGitOpsFileMode); err != nil { //nolint:gosec // Bootstrap marker is non-secret and must be pod-readable.
+	if err := os.WriteFile(markerPath, []byte(content), LocalGitOpsFileMode); err != nil {
 		span.RecordError(err)
 		return fmt.Errorf("failed to write bootstrap marker: %w", err)
 	}
-	if err := os.Chmod(markerPath, LocalGitOpsFileMode); err != nil { //nolint:gosec // Bootstrap marker is non-secret and must be pod-readable.
+	if err := os.Chmod(markerPath, LocalGitOpsFileMode); err != nil {
 		span.RecordError(err)
 		return fmt.Errorf("failed to set bootstrap marker permissions: %w", err)
 	}

--- a/pkg/git/client_impl.go
+++ b/pkg/git/client_impl.go
@@ -271,11 +271,11 @@ func (c *ClientImpl) initLocalPath(ctx context.Context) error {
 
 	// Ensure working directory exists
 	if c.cfg.Path != "" {
-		if err := os.MkdirAll(c.workDir, LocalGitOpsDirMode); err != nil {
+		if err := os.MkdirAll(c.workDir, GitOpsDirMode); err != nil {
 			span.RecordError(err)
 			return fmt.Errorf("failed to create subdirectory %s: %w", c.cfg.Path, err)
 		}
-		if err := os.Chmod(c.workDir, LocalGitOpsDirMode); err != nil {
+		if err := os.Chmod(c.workDir, GitOpsDirMode); err != nil {
 			span.RecordError(err)
 			return fmt.Errorf("failed to set subdirectory permissions %s: %w", c.cfg.Path, err)
 		}
@@ -435,9 +435,9 @@ func (c *ClientImpl) NormalizeLocalPermissions(ctx context.Context) error {
 			return nil
 		}
 
-		mode := LocalGitOpsFileMode
+		mode := GitOpsFileMode
 		if d.IsDir() {
-			mode = LocalGitOpsDirMode
+			mode = GitOpsDirMode
 		}
 		if err := rootDir.Chmod(path, mode); err != nil {
 			return fmt.Errorf("set permissions on %s: %w", path, err)
@@ -592,11 +592,11 @@ func (c *ClientImpl) WriteBootstrapMarker(ctx context.Context) error {
 
 	content := fmt.Sprintf("bootstrapped_at: %s\n", time.Now().UTC().Format(time.RFC3339))
 
-	if err := os.WriteFile(markerPath, []byte(content), LocalGitOpsFileMode); err != nil {
+	if err := os.WriteFile(markerPath, []byte(content), GitOpsFileMode); err != nil {
 		span.RecordError(err)
 		return fmt.Errorf("failed to write bootstrap marker: %w", err)
 	}
-	if err := os.Chmod(markerPath, LocalGitOpsFileMode); err != nil {
+	if err := os.Chmod(markerPath, GitOpsFileMode); err != nil {
 		span.RecordError(err)
 		return fmt.Errorf("failed to set bootstrap marker permissions: %w", err)
 	}

--- a/pkg/git/client_impl.go
+++ b/pkg/git/client_impl.go
@@ -275,10 +275,6 @@ func (c *ClientImpl) initLocalPath(ctx context.Context) error {
 			span.RecordError(err)
 			return fmt.Errorf("failed to create subdirectory %s: %w", c.cfg.Path, err)
 		}
-		if err := os.Chmod(c.workDir, GitOpsDirMode); err != nil {
-			span.RecordError(err)
-			return fmt.Errorf("failed to set subdirectory permissions %s: %w", c.cfg.Path, err)
-		}
 	}
 
 	// Check if .git directory exists
@@ -403,12 +399,18 @@ func (c *ClientImpl) WorkDir() string {
 	return c.workDir
 }
 
-// NormalizeLocalPermissions normalizes a local file:// GitOps repository tree,
+// normalizeLocalPermissions normalizes a local file:// GitOps repository tree,
 // including .git, so ArgoCD's non-root repo-server can read refs and generated
 // manifests through a read-only kind hostPath mount. Symlinks are skipped.
-func (c *ClientImpl) NormalizeLocalPermissions(ctx context.Context) error {
+//
+// This is load-bearing, not defensive: git/go-git create .git contents under the
+// deploying user's umask, so a restrictive umask (e.g. 077) yields 0600/0700
+// objects the repo-server cannot read. It runs on the write path (after commit),
+// which is the only point new content is produced; we intentionally do not
+// re-walk an already-bootstrapped repo on the skip path.
+func (c *ClientImpl) normalizeLocalPermissions(ctx context.Context) error {
 	tracer := otel.Tracer(tracerName)
-	_, span := tracer.Start(ctx, "git.NormalizeLocalPermissions")
+	_, span := tracer.Start(ctx, "git.normalizeLocalPermissions")
 	defer span.End()
 	span.SetAttributes(attribute.String("git.repo_path", c.repoPath))
 
@@ -470,7 +472,15 @@ func (c *ClientImpl) CommitAndPush(ctx context.Context, message string) error {
 	// For local paths, only commit (no push)
 	if c.cfg.IsLocalPath() {
 		span.SetAttributes(attribute.Bool("git.local_path", true))
-		return c.commitLocal(ctx, message)
+		if err := c.commitLocal(ctx, message); err != nil {
+			span.RecordError(err)
+			return err
+		}
+		if err := c.normalizeLocalPermissions(ctx); err != nil {
+			span.RecordError(err)
+			return err
+		}
+		return nil
 	}
 
 	// Stage and commit changes

--- a/pkg/git/client_impl.go
+++ b/pkg/git/client_impl.go
@@ -265,9 +265,13 @@ func (c *ClientImpl) initLocalPath(ctx context.Context) error {
 
 	// Ensure working directory exists
 	if c.cfg.Path != "" {
-		if err := os.MkdirAll(c.workDir, 0750); err != nil {
+		if err := os.MkdirAll(c.workDir, LocalGitOpsDirMode); err != nil { //nolint:gosec // Local GitOps path must be readable by ArgoCD's non-root repo-server.
 			span.RecordError(err)
 			return fmt.Errorf("failed to create subdirectory %s: %w", c.cfg.Path, err)
+		}
+		if err := os.Chmod(c.workDir, LocalGitOpsDirMode); err != nil { //nolint:gosec // Local GitOps path must be readable by ArgoCD's non-root repo-server.
+			span.RecordError(err)
+			return fmt.Errorf("failed to set subdirectory permissions %s: %w", c.cfg.Path, err)
 		}
 	}
 
@@ -534,9 +538,13 @@ func (c *ClientImpl) WriteBootstrapMarker(ctx context.Context) error {
 
 	content := fmt.Sprintf("bootstrapped_at: %s\n", time.Now().UTC().Format(time.RFC3339))
 
-	if err := os.WriteFile(markerPath, []byte(content), 0600); err != nil {
+	if err := os.WriteFile(markerPath, []byte(content), LocalGitOpsFileMode); err != nil { //nolint:gosec // Bootstrap marker is non-secret and must be pod-readable.
 		span.RecordError(err)
 		return fmt.Errorf("failed to write bootstrap marker: %w", err)
+	}
+	if err := os.Chmod(markerPath, LocalGitOpsFileMode); err != nil { //nolint:gosec // Bootstrap marker is non-secret and must be pod-readable.
+		span.RecordError(err)
+		return fmt.Errorf("failed to set bootstrap marker permissions: %w", err)
 	}
 
 	return nil

--- a/pkg/git/client_impl_test.go
+++ b/pkg/git/client_impl_test.go
@@ -306,8 +306,8 @@ func TestClientWriteBootstrapMarker(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to stat marker file: %v", err)
 	}
-	if got := markerInfo.Mode().Perm(); got != LocalGitOpsFileMode {
-		t.Errorf("marker file mode = %v, want %v", got, LocalGitOpsFileMode)
+	if got := markerInfo.Mode().Perm(); got != GitOpsFileMode {
+		t.Errorf("marker file mode = %v, want %v", got, GitOpsFileMode)
 	}
 
 	// Verify IsBootstrapped returns true
@@ -849,7 +849,7 @@ func TestClientNormalizeLocalPermissions(t *testing.T) {
 			},
 			check: func(t *testing.T, root string) {
 				t.Helper()
-				assertPathMode(t, root, LocalGitOpsDirMode)
+				assertPathMode(t, root, GitOpsDirMode)
 			},
 		},
 		{
@@ -867,7 +867,7 @@ func TestClientNormalizeLocalPermissions(t *testing.T) {
 			},
 			check: func(t *testing.T, root string) {
 				t.Helper()
-				assertPathMode(t, filepath.Join(root, "apps", "root"), LocalGitOpsDirMode)
+				assertPathMode(t, filepath.Join(root, "apps", "root"), GitOpsDirMode)
 			},
 		},
 		{
@@ -885,7 +885,7 @@ func TestClientNormalizeLocalPermissions(t *testing.T) {
 			},
 			check: func(t *testing.T, root string) {
 				t.Helper()
-				assertPathMode(t, filepath.Join(root, "nic-config.yaml"), LocalGitOpsFileMode)
+				assertPathMode(t, filepath.Join(root, "nic-config.yaml"), GitOpsFileMode)
 			},
 		},
 		{
@@ -913,9 +913,9 @@ func TestClientNormalizeLocalPermissions(t *testing.T) {
 			},
 			check: func(t *testing.T, root string) {
 				t.Helper()
-				assertPathMode(t, filepath.Join(root, ".git"), LocalGitOpsDirMode)
-				assertPathMode(t, filepath.Join(root, ".git", "objects"), LocalGitOpsDirMode)
-				assertPathMode(t, filepath.Join(root, ".git", "HEAD"), LocalGitOpsFileMode)
+				assertPathMode(t, filepath.Join(root, ".git"), GitOpsDirMode)
+				assertPathMode(t, filepath.Join(root, ".git", "objects"), GitOpsDirMode)
+				assertPathMode(t, filepath.Join(root, ".git", "HEAD"), GitOpsFileMode)
 			},
 		},
 		{

--- a/pkg/git/client_impl_test.go
+++ b/pkg/git/client_impl_test.go
@@ -828,6 +828,7 @@ func TestClientCommitLocalOnFreshRepo(t *testing.T) {
 	if commit.Message != "First commit on fresh repo" {
 		t.Errorf("commit message = %q, want %q", commit.Message, "First commit on fresh repo")
 	}
+	assertPathMode(t, filePath, GitOpsFileMode)
 }
 
 func TestClientNormalizeLocalPermissions(t *testing.T) {
@@ -965,18 +966,18 @@ func TestClientNormalizeLocalPermissions(t *testing.T) {
 				repoPath: repoPath,
 			}
 
-			err := client.NormalizeLocalPermissions(context.Background())
+			err := client.normalizeLocalPermissions(context.Background())
 			if tt.wantErr {
 				if err == nil {
-					t.Fatalf("NormalizeLocalPermissions() expected error")
+					t.Fatalf("normalizeLocalPermissions() expected error")
 				}
 				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
-					t.Fatalf("NormalizeLocalPermissions() error = %v, want containing %q", err, tt.errContains)
+					t.Fatalf("normalizeLocalPermissions() error = %v, want containing %q", err, tt.errContains)
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("NormalizeLocalPermissions() error: %v", err)
+				t.Fatalf("normalizeLocalPermissions() error: %v", err)
 			}
 			tt.check(t, root)
 		})

--- a/pkg/git/client_impl_test.go
+++ b/pkg/git/client_impl_test.go
@@ -830,6 +830,170 @@ func TestClientCommitLocalOnFreshRepo(t *testing.T) {
 	}
 }
 
+func TestClientNormalizeLocalPermissions(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(t *testing.T, root string) string
+		check       func(t *testing.T, root string)
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "root directory",
+			setup: func(t *testing.T, root string) string {
+				t.Helper()
+				if err := os.Chmod(root, 0o700); err != nil { //nolint:gosec // Deliberately restrictive setup for permission normalization.
+					t.Fatalf("chmod root: %v", err)
+				}
+				return root
+			},
+			check: func(t *testing.T, root string) {
+				t.Helper()
+				assertPathMode(t, root, LocalGitOpsDirMode)
+			},
+		},
+		{
+			name: "nested directories",
+			setup: func(t *testing.T, root string) string {
+				t.Helper()
+				nested := filepath.Join(root, "apps", "root")
+				if err := os.MkdirAll(nested, 0o700); err != nil {
+					t.Fatalf("mkdir nested: %v", err)
+				}
+				if err := os.Chmod(nested, 0o700); err != nil { //nolint:gosec // Deliberately restrictive setup for permission normalization.
+					t.Fatalf("chmod nested: %v", err)
+				}
+				return root
+			},
+			check: func(t *testing.T, root string) {
+				t.Helper()
+				assertPathMode(t, filepath.Join(root, "apps", "root"), LocalGitOpsDirMode)
+			},
+		},
+		{
+			name: "regular files",
+			setup: func(t *testing.T, root string) string {
+				t.Helper()
+				path := filepath.Join(root, "nic-config.yaml")
+				if err := os.WriteFile(path, []byte("project_name: test\n"), 0o600); err != nil {
+					t.Fatalf("write file: %v", err)
+				}
+				if err := os.Chmod(path, 0o600); err != nil {
+					t.Fatalf("chmod file: %v", err)
+				}
+				return root
+			},
+			check: func(t *testing.T, root string) {
+				t.Helper()
+				assertPathMode(t, filepath.Join(root, "nic-config.yaml"), LocalGitOpsFileMode)
+			},
+		},
+		{
+			name: ".git contents",
+			setup: func(t *testing.T, root string) string {
+				t.Helper()
+				objects := filepath.Join(root, ".git", "objects")
+				if err := os.MkdirAll(objects, 0o700); err != nil {
+					t.Fatalf("mkdir .git objects: %v", err)
+				}
+				if err := os.Chmod(filepath.Join(root, ".git"), 0o700); err != nil { //nolint:gosec // Deliberately restrictive setup for permission normalization.
+					t.Fatalf("chmod .git: %v", err)
+				}
+				if err := os.Chmod(objects, 0o700); err != nil { //nolint:gosec // Deliberately restrictive setup for permission normalization.
+					t.Fatalf("chmod objects: %v", err)
+				}
+				head := filepath.Join(root, ".git", "HEAD")
+				if err := os.WriteFile(head, []byte("ref: refs/heads/main\n"), 0o600); err != nil {
+					t.Fatalf("write HEAD: %v", err)
+				}
+				if err := os.Chmod(head, 0o600); err != nil {
+					t.Fatalf("chmod HEAD: %v", err)
+				}
+				return root
+			},
+			check: func(t *testing.T, root string) {
+				t.Helper()
+				assertPathMode(t, filepath.Join(root, ".git"), LocalGitOpsDirMode)
+				assertPathMode(t, filepath.Join(root, ".git", "objects"), LocalGitOpsDirMode)
+				assertPathMode(t, filepath.Join(root, ".git", "HEAD"), LocalGitOpsFileMode)
+			},
+		},
+		{
+			name: "symlink skip",
+			setup: func(t *testing.T, root string) string {
+				t.Helper()
+				target := filepath.Join(t.TempDir(), "target")
+				if err := os.WriteFile(target, []byte("target"), 0o600); err != nil {
+					t.Fatalf("write symlink target: %v", err)
+				}
+				if err := os.Chmod(target, 0o600); err != nil {
+					t.Fatalf("chmod symlink target: %v", err)
+				}
+				link := filepath.Join(root, "linked-target")
+				if err := os.Symlink(target, link); err != nil {
+					t.Skipf("symlink unavailable: %v", err)
+				}
+				return root
+			},
+			check: func(t *testing.T, root string) {
+				t.Helper()
+				link := filepath.Join(root, "linked-target")
+				target, err := os.Readlink(link)
+				if err != nil {
+					t.Fatalf("readlink: %v", err)
+				}
+				assertPathMode(t, target, 0o600)
+			},
+		},
+		{
+			name: "missing root error",
+			setup: func(t *testing.T, root string) string {
+				t.Helper()
+				return filepath.Join(root, "missing")
+			},
+			wantErr:     true,
+			errContains: "open local gitops root",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			repoPath := tt.setup(t, root)
+			client := &ClientImpl{
+				cfg:      &Config{URL: "file://" + repoPath},
+				repoPath: repoPath,
+			}
+
+			err := client.NormalizeLocalPermissions(context.Background())
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("NormalizeLocalPermissions() expected error")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Fatalf("NormalizeLocalPermissions() error = %v, want containing %q", err, tt.errContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NormalizeLocalPermissions() error: %v", err)
+			}
+			tt.check(t, root)
+		})
+	}
+}
+
+func assertPathMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("%s mode = %v, want %v", path, got, want)
+	}
+}
+
 func TestClientCommitAndPushNotInitialized(t *testing.T) {
 	client := &ClientImpl{
 		cfg:     &Config{URL: "file:///test"},

--- a/pkg/git/client_impl_test.go
+++ b/pkg/git/client_impl_test.go
@@ -302,6 +302,14 @@ func TestClientWriteBootstrapMarker(t *testing.T) {
 		t.Errorf("marker file content = %q, want to contain 'bootstrapped_at'", content)
 	}
 
+	markerInfo, err := os.Stat(markerPath)
+	if err != nil {
+		t.Fatalf("failed to stat marker file: %v", err)
+	}
+	if got := markerInfo.Mode().Perm(); got != LocalGitOpsFileMode {
+		t.Errorf("marker file mode = %v, want %v", got, LocalGitOpsFileMode)
+	}
+
 	// Verify IsBootstrapped returns true
 	bootstrapped, err := client.IsBootstrapped(context.Background())
 	if err != nil {
@@ -774,7 +782,7 @@ func TestClientCommitAndPush(t *testing.T) {
 
 func TestClientCommitLocalOnFreshRepo(t *testing.T) {
 	// Exercise CommitAndPush on a freshly PlainInit'd local repo with zero commits.
-	// This is the path taken when the auto-generated /tmp/nebari-gitops-{name}
+	// This is the path taken when the auto-generated local GitOps
 	// directory is brand new.
 	tmpDir, err := os.MkdirTemp("", "test-fresh-local-*")
 	if err != nil {

--- a/pkg/git/config.go
+++ b/pkg/git/config.go
@@ -15,15 +15,25 @@ import (
 const (
 	// DefaultBranch is the default git branch name when none is specified.
 	DefaultBranch = "main"
+
+	// LocalGitOpsDirMode is the directory mode for local file:// GitOps repos
+	// that must be readable by non-root ArgoCD pods through a kind hostPath mount.
+	LocalGitOpsDirMode os.FileMode = 0o755
+
+	// LocalGitOpsFileMode is the file mode for generated non-secret GitOps files.
+	LocalGitOpsFileMode os.FileMode = 0o644
 )
 
 // DefaultLocalPath returns the host directory NIC manages for a project's
-// local gitops repository when no git_repository is configured. It is a pure
-// function so the deploy orchestrator and providers that mount the directory
-// (e.g. the local kind provider) can derive the same path independently
-// without threading it between them.
+// local gitops repository when no git_repository is configured. It lives under
+// the user's home directory so the repo is durable and stays on host paths that
+// kind/Docker Desktop can mount reliably.
 func DefaultLocalPath(projectName string) string {
-	return filepath.Join(os.TempDir(), fmt.Sprintf("nebari-gitops-%s", projectName))
+	homeDir, err := os.UserHomeDir()
+	if err != nil || homeDir == "" {
+		return filepath.Join(os.TempDir(), fmt.Sprintf("nebari-gitops-%s", projectName))
+	}
+	return filepath.Join(homeDir, ".nebari", "gitops", projectName)
 }
 
 // Config represents git repository configuration for GitOps bootstrap.

--- a/pkg/git/config.go
+++ b/pkg/git/config.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,6 +10,8 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	cryptossh "golang.org/x/crypto/ssh"
 )
 
@@ -24,16 +27,37 @@ const (
 	LocalGitOpsFileMode os.FileMode = 0o644
 )
 
+var userHomeDir = os.UserHomeDir
+
 // DefaultLocalPath returns the host directory NIC manages for a project's
 // local gitops repository when no git_repository is configured. It lives under
 // the user's home directory so the repo is durable and stays on host paths that
 // kind/Docker Desktop can mount reliably.
 func DefaultLocalPath(projectName string) string {
-	homeDir, err := os.UserHomeDir()
+	homeDir, err := userHomeDir()
 	if err != nil || homeDir == "" {
 		return filepath.Join(os.TempDir(), fmt.Sprintf("nebari-gitops-%s", projectName))
 	}
 	return filepath.Join(homeDir, ".nic", "gitops", projectName)
+}
+
+// EnsureLocalGitOpsDir creates a NIC-managed local GitOps root and sets its
+// permissions so non-root ArgoCD pods can read it through a kind hostPath mount.
+func EnsureLocalGitOpsDir(ctx context.Context, path string) error {
+	tracer := otel.Tracer(tracerName)
+	_, span := tracer.Start(ctx, "git.EnsureLocalGitOpsDir")
+	defer span.End()
+	span.SetAttributes(attribute.String("local_path", path))
+
+	if err := os.MkdirAll(path, LocalGitOpsDirMode); err != nil {
+		span.RecordError(err)
+		return fmt.Errorf("create local gitops directory %s: %w", path, err)
+	}
+	if err := os.Chmod(path, LocalGitOpsDirMode); err != nil {
+		span.RecordError(err)
+		return fmt.Errorf("set local gitops directory permissions %s: %w", path, err)
+	}
+	return nil
 }
 
 // Config represents git repository configuration for GitOps bootstrap.

--- a/pkg/git/config.go
+++ b/pkg/git/config.go
@@ -19,12 +19,11 @@ const (
 	// DefaultBranch is the default git branch name when none is specified.
 	DefaultBranch = "main"
 
-	// LocalGitOpsDirMode is the directory mode for local file:// GitOps repos
-	// that must be readable by non-root ArgoCD pods through a kind hostPath mount.
-	LocalGitOpsDirMode os.FileMode = 0o755
+	// GitOpsDirMode is the directory mode for generated GitOps repository content.
+	GitOpsDirMode os.FileMode = 0o755
 
-	// LocalGitOpsFileMode is the file mode for generated non-secret GitOps files.
-	LocalGitOpsFileMode os.FileMode = 0o644
+	// GitOpsFileMode is the file mode for generated non-secret GitOps files.
+	GitOpsFileMode os.FileMode = 0o644
 )
 
 var userHomeDir = os.UserHomeDir
@@ -47,13 +46,13 @@ func EnsureLocalGitOpsDir(ctx context.Context, path string) error {
 	tracer := otel.Tracer(tracerName)
 	_, span := tracer.Start(ctx, "git.EnsureLocalGitOpsDir")
 	defer span.End()
-	span.SetAttributes(attribute.String("local_path", path))
+	span.SetAttributes(attribute.String("git.repo_path", path))
 
-	if err := os.MkdirAll(path, LocalGitOpsDirMode); err != nil {
+	if err := os.MkdirAll(path, GitOpsDirMode); err != nil {
 		span.RecordError(err)
 		return fmt.Errorf("create local gitops directory %s: %w", path, err)
 	}
-	if err := os.Chmod(path, LocalGitOpsDirMode); err != nil {
+	if err := os.Chmod(path, GitOpsDirMode); err != nil {
 		span.RecordError(err)
 		return fmt.Errorf("set local gitops directory permissions %s: %w", path, err)
 	}

--- a/pkg/git/config.go
+++ b/pkg/git/config.go
@@ -33,7 +33,7 @@ func DefaultLocalPath(projectName string) string {
 	if err != nil || homeDir == "" {
 		return filepath.Join(os.TempDir(), fmt.Sprintf("nebari-gitops-%s", projectName))
 	}
-	return filepath.Join(homeDir, ".nebari", "gitops", projectName)
+	return filepath.Join(homeDir, ".nic", "gitops", projectName)
 }
 
 // Config represents git repository configuration for GitOps bootstrap.

--- a/pkg/git/config_test.go
+++ b/pkg/git/config_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,15 +11,48 @@ import (
 )
 
 func TestDefaultLocalPath(t *testing.T) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil || homeDir == "" {
-		t.Skipf("user home directory unavailable: %v", err)
+	originalUserHomeDir := userHomeDir
+	defer func() {
+		userHomeDir = originalUserHomeDir
+	}()
+
+	tests := []struct {
+		name        string
+		userHomeDir func() (string, error)
+		want        string
+	}{
+		{
+			name: "uses home directory",
+			userHomeDir: func() (string, error) {
+				return filepath.Join("home", "test-user"), nil
+			},
+			want: filepath.Join("home", "test-user", ".nic", "gitops", "my-nebari-local"),
+		},
+		{
+			name: "falls back to temp dir when home directory errors",
+			userHomeDir: func() (string, error) {
+				return "", errors.New("home unavailable")
+			},
+			want: filepath.Join(os.TempDir(), "nebari-gitops-my-nebari-local"),
+		},
+		{
+			name: "falls back to temp dir when home directory is empty",
+			userHomeDir: func() (string, error) {
+				return "", nil
+			},
+			want: filepath.Join(os.TempDir(), "nebari-gitops-my-nebari-local"),
+		},
 	}
 
-	got := DefaultLocalPath("my-nebari-local")
-	want := filepath.Join(homeDir, ".nic", "gitops", "my-nebari-local")
-	if got != want {
-		t.Fatalf("DefaultLocalPath() = %q, want %q", got, want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			userHomeDir = tt.userHomeDir
+
+			got := DefaultLocalPath("my-nebari-local")
+			if got != tt.want {
+				t.Fatalf("DefaultLocalPath() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/pkg/git/config_test.go
+++ b/pkg/git/config_test.go
@@ -2,11 +2,25 @@ package git
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/go-git/go-git/v5/plumbing/transport"
 )
+
+func TestDefaultLocalPath(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil || homeDir == "" {
+		t.Skipf("user home directory unavailable: %v", err)
+	}
+
+	got := DefaultLocalPath("my-nebari-local")
+	want := filepath.Join(homeDir, ".nebari", "gitops", "my-nebari-local")
+	if got != want {
+		t.Fatalf("DefaultLocalPath() = %q, want %q", got, want)
+	}
+}
 
 func TestConfigValidate(t *testing.T) {
 	tests := []struct {

--- a/pkg/git/config_test.go
+++ b/pkg/git/config_test.go
@@ -16,7 +16,7 @@ func TestDefaultLocalPath(t *testing.T) {
 	}
 
 	got := DefaultLocalPath("my-nebari-local")
-	want := filepath.Join(homeDir, ".nebari", "gitops", "my-nebari-local")
+	want := filepath.Join(homeDir, ".nic", "gitops", "my-nebari-local")
 	if got != want {
 		t.Fatalf("DefaultLocalPath() = %q, want %q", got, want)
 	}

--- a/pkg/nic/deploy.go
+++ b/pkg/nic/deploy.go
@@ -519,16 +519,16 @@ func (c *Client) writeConfigToRepo(ctx context.Context, cfg *config.NebariConfig
 	}
 
 	configDest := filepath.Join(workDir, "nic-config.yaml")
-	if err := os.MkdirAll(filepath.Dir(configDest), git.LocalGitOpsDirMode); err != nil {
+	if err := os.MkdirAll(filepath.Dir(configDest), git.GitOpsDirMode); err != nil {
 		return fmt.Errorf("create config directory: %w", err)
 	}
-	if err := os.Chmod(filepath.Dir(configDest), git.LocalGitOpsDirMode); err != nil {
+	if err := os.Chmod(filepath.Dir(configDest), git.GitOpsDirMode); err != nil {
 		return fmt.Errorf("set config directory permissions: %w", err)
 	}
-	if err := os.WriteFile(configDest, configBytes, git.LocalGitOpsFileMode); err != nil {
+	if err := os.WriteFile(configDest, configBytes, git.GitOpsFileMode); err != nil {
 		return fmt.Errorf("write config to repository: %w", err)
 	}
-	if err := os.Chmod(configDest, git.LocalGitOpsFileMode); err != nil {
+	if err := os.Chmod(configDest, git.GitOpsFileMode); err != nil {
 		return fmt.Errorf("set config file permissions: %w", err)
 	}
 	status.Send(ctx, status.NewUpdate(status.LevelInfo, "Wrote NIC config to repository (auth fields scrubbed)").

--- a/pkg/nic/deploy.go
+++ b/pkg/nic/deploy.go
@@ -259,7 +259,7 @@ func defaultGitConfig(projectName string) *git.Config {
 
 // getOrCreateGitConfig returns the git configuration, creating a default local one if none is configured.
 // For providers that support local gitops without explicit git_repository config, this auto-creates
-// ~/.nebari/gitops/{project_name}. For other providers, explicit git_repository config is required.
+// ~/.nic/gitops/{project_name}. For other providers, explicit git_repository config is required.
 // The supportsLocalGitOps parameter comes from cluster.InfraSettings().SupportsLocalGitOps.
 func (c *Client) getOrCreateGitConfig(ctx context.Context, cfg *config.NebariConfig, supportsLocalGitOps bool) (*git.Config, error) {
 	if cfg.GitRepository != nil {

--- a/pkg/nic/deploy.go
+++ b/pkg/nic/deploy.go
@@ -283,10 +283,10 @@ func (c *Client) getOrCreateGitConfig(ctx context.Context, cfg *config.NebariCon
 	status.Send(ctx, status.NewUpdate(status.LevelInfo, "No git_repository configured, using auto-generated local directory").
 		WithMetadata("path", localPath))
 
-	if err := os.MkdirAll(localPath, git.LocalGitOpsDirMode); err != nil { //nolint:gosec // Local GitOps repo must be readable by ArgoCD's non-root repo-server.
+	if err := os.MkdirAll(localPath, git.LocalGitOpsDirMode); err != nil {
 		return nil, fmt.Errorf("failed to create auto-generated directory %s: %w", localPath, err)
 	}
-	if err := os.Chmod(localPath, git.LocalGitOpsDirMode); err != nil { //nolint:gosec // Local GitOps repo must be readable by ArgoCD's non-root repo-server.
+	if err := os.Chmod(localPath, git.LocalGitOpsDirMode); err != nil {
 		return nil, fmt.Errorf("failed to set auto-generated directory permissions %s: %w", localPath, err)
 	}
 
@@ -508,16 +508,16 @@ func (c *Client) writeConfigToRepo(ctx context.Context, cfg *config.NebariConfig
 	}
 
 	configDest := filepath.Join(workDir, "nic-config.yaml")
-	if err := os.MkdirAll(filepath.Dir(configDest), git.LocalGitOpsDirMode); err != nil { //nolint:gosec // Local GitOps config snapshot must be pod-readable.
+	if err := os.MkdirAll(filepath.Dir(configDest), git.LocalGitOpsDirMode); err != nil {
 		return fmt.Errorf("create config directory: %w", err)
 	}
-	if err := os.Chmod(filepath.Dir(configDest), git.LocalGitOpsDirMode); err != nil { //nolint:gosec // Local GitOps config snapshot must be pod-readable.
+	if err := os.Chmod(filepath.Dir(configDest), git.LocalGitOpsDirMode); err != nil {
 		return fmt.Errorf("set config directory permissions: %w", err)
 	}
-	if err := os.WriteFile(configDest, configBytes, git.LocalGitOpsFileMode); err != nil { //nolint:gosec // Scrubbed config snapshot is non-secret and must be pod-readable.
+	if err := os.WriteFile(configDest, configBytes, git.LocalGitOpsFileMode); err != nil {
 		return fmt.Errorf("write config to repository: %w", err)
 	}
-	if err := os.Chmod(configDest, git.LocalGitOpsFileMode); err != nil { //nolint:gosec // Scrubbed config snapshot is non-secret and must be pod-readable.
+	if err := os.Chmod(configDest, git.LocalGitOpsFileMode); err != nil {
 		return fmt.Errorf("set config file permissions: %w", err)
 	}
 	status.Send(ctx, status.NewUpdate(status.LevelInfo, "Wrote NIC config to repository (auth fields scrubbed)").
@@ -534,16 +534,28 @@ func ensureLocalGitOpsPermissions(ctx context.Context, root string) error {
 	defer span.End()
 	span.SetAttributes(attribute.String("local_path", root))
 
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+	rootDir, err := os.OpenRoot(root)
+	if err != nil {
+		span.RecordError(err)
+		return fmt.Errorf("open local gitops root %s: %w", root, err)
+	}
+	defer func() {
+		_ = rootDir.Close()
+	}()
+
+	err = fs.WalkDir(rootDir.FS(), ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
+		}
+		if d.Type()&fs.ModeSymlink != 0 {
+			return nil
 		}
 
 		mode := git.LocalGitOpsFileMode
 		if d.IsDir() {
 			mode = git.LocalGitOpsDirMode
 		}
-		if err := os.Chmod(path, mode); err != nil {
+		if err := rootDir.Chmod(path, mode); err != nil {
 			return fmt.Errorf("set permissions on %s: %w", path, err)
 		}
 		return nil

--- a/pkg/nic/deploy.go
+++ b/pkg/nic/deploy.go
@@ -434,12 +434,6 @@ func (c *Client) bootstrapGitOps(ctx context.Context, cfg *config.NebariConfig, 
 		span.RecordError(err)
 		return fmt.Errorf("failed to initialize git repository: %w", err)
 	}
-	if isLocal {
-		if err := gitClient.NormalizeLocalPermissions(ctx); err != nil {
-			span.RecordError(err)
-			return err
-		}
-	}
 
 	// Check if already bootstrapped
 	bootstrapped, err := gitClient.IsBootstrapped(ctx)
@@ -489,13 +483,6 @@ func (c *Client) bootstrapGitOps(ctx context.Context, cfg *config.NebariConfig, 
 			return fmt.Errorf("failed to commit: %w", err)
 		}
 		return fmt.Errorf("failed to commit and push: %w", err)
-	}
-
-	if isLocal {
-		if err := gitClient.NormalizeLocalPermissions(ctx); err != nil {
-			span.RecordError(err)
-			return err
-		}
 	}
 
 	if isLocal {

--- a/pkg/nic/deploy.go
+++ b/pkg/nic/deploy.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"time"
@@ -258,7 +259,7 @@ func defaultGitConfig(projectName string) *git.Config {
 
 // getOrCreateGitConfig returns the git configuration, creating a default local one if none is configured.
 // For providers that support local gitops without explicit git_repository config, this auto-creates
-// /tmp/nebari-gitops-{project_name}. For other providers, explicit git_repository config is required.
+// ~/.nebari/gitops/{project_name}. For other providers, explicit git_repository config is required.
 // The supportsLocalGitOps parameter comes from cluster.InfraSettings().SupportsLocalGitOps.
 func (c *Client) getOrCreateGitConfig(ctx context.Context, cfg *config.NebariConfig, supportsLocalGitOps bool) (*git.Config, error) {
 	if cfg.GitRepository != nil {
@@ -282,8 +283,11 @@ func (c *Client) getOrCreateGitConfig(ctx context.Context, cfg *config.NebariCon
 	status.Send(ctx, status.NewUpdate(status.LevelInfo, "No git_repository configured, using auto-generated local directory").
 		WithMetadata("path", localPath))
 
-	if err := os.MkdirAll(localPath, 0750); err != nil {
+	if err := os.MkdirAll(localPath, git.LocalGitOpsDirMode); err != nil { //nolint:gosec // Local GitOps repo must be readable by ArgoCD's non-root repo-server.
 		return nil, fmt.Errorf("failed to create auto-generated directory %s: %w", localPath, err)
+	}
+	if err := os.Chmod(localPath, git.LocalGitOpsDirMode); err != nil { //nolint:gosec // Local GitOps repo must be readable by ArgoCD's non-root repo-server.
+		return nil, fmt.Errorf("failed to set auto-generated directory permissions %s: %w", localPath, err)
 	}
 
 	return gitCfg, nil
@@ -428,6 +432,12 @@ func (c *Client) bootstrapGitOps(ctx context.Context, cfg *config.NebariConfig, 
 	}
 
 	if bootstrapped && !regenApps {
+		if isLocal && cfg.GitRepository == nil {
+			if err := ensureLocalGitOpsPermissions(ctx, localPath); err != nil {
+				span.RecordError(err)
+				return err
+			}
+		}
 		status.Info(ctx, "GitOps repository already bootstrapped, skipping manifest generation")
 		span.SetAttributes(attribute.Bool("skipped", true))
 		return nil
@@ -470,6 +480,13 @@ func (c *Client) bootstrapGitOps(ctx context.Context, cfg *config.NebariConfig, 
 		return fmt.Errorf("failed to commit and push: %w", err)
 	}
 
+	if isLocal && cfg.GitRepository == nil {
+		if err := ensureLocalGitOpsPermissions(ctx, localPath); err != nil {
+			span.RecordError(err)
+			return err
+		}
+	}
+
 	if isLocal {
 		status.Send(ctx, status.NewUpdate(status.LevelSuccess, "Local GitOps directory bootstrapped successfully").
 			WithMetadata("path", localPath))
@@ -491,14 +508,50 @@ func (c *Client) writeConfigToRepo(ctx context.Context, cfg *config.NebariConfig
 	}
 
 	configDest := filepath.Join(workDir, "nic-config.yaml")
-	if err := os.MkdirAll(filepath.Dir(configDest), 0750); err != nil {
+	if err := os.MkdirAll(filepath.Dir(configDest), git.LocalGitOpsDirMode); err != nil { //nolint:gosec // Local GitOps config snapshot must be pod-readable.
 		return fmt.Errorf("create config directory: %w", err)
 	}
-	if err := os.WriteFile(configDest, configBytes, 0600); err != nil {
+	if err := os.Chmod(filepath.Dir(configDest), git.LocalGitOpsDirMode); err != nil { //nolint:gosec // Local GitOps config snapshot must be pod-readable.
+		return fmt.Errorf("set config directory permissions: %w", err)
+	}
+	if err := os.WriteFile(configDest, configBytes, git.LocalGitOpsFileMode); err != nil { //nolint:gosec // Scrubbed config snapshot is non-secret and must be pod-readable.
 		return fmt.Errorf("write config to repository: %w", err)
+	}
+	if err := os.Chmod(configDest, git.LocalGitOpsFileMode); err != nil { //nolint:gosec // Scrubbed config snapshot is non-secret and must be pod-readable.
+		return fmt.Errorf("set config file permissions: %w", err)
 	}
 	status.Send(ctx, status.NewUpdate(status.LevelInfo, "Wrote NIC config to repository (auth fields scrubbed)").
 		WithMetadata("path", configDest))
+	return nil
+}
+
+// ensureLocalGitOpsPermissions normalizes NIC-managed local GitOps repositories
+// so ArgoCD's non-root repo-server can read refs and generated manifests through
+// a read-only kind hostPath mount.
+func ensureLocalGitOpsPermissions(ctx context.Context, root string) error {
+	tracer := otel.Tracer("nebari-infrastructure-core")
+	_, span := tracer.Start(ctx, "nic.ensureLocalGitOpsPermissions")
+	defer span.End()
+	span.SetAttributes(attribute.String("local_path", root))
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		mode := git.LocalGitOpsFileMode
+		if d.IsDir() {
+			mode = git.LocalGitOpsDirMode
+		}
+		if err := os.Chmod(path, mode); err != nil {
+			return fmt.Errorf("set permissions on %s: %w", path, err)
+		}
+		return nil
+	})
+	if err != nil {
+		span.RecordError(err)
+		return fmt.Errorf("set local gitops permissions under %s: %w", root, err)
+	}
 	return nil
 }
 

--- a/pkg/nic/deploy.go
+++ b/pkg/nic/deploy.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"time"
@@ -298,11 +297,8 @@ func (c *Client) getOrCreateGitConfig(ctx context.Context, cfg *config.NebariCon
 	status.Send(ctx, status.NewUpdate(status.LevelInfo, "No git_repository configured, using auto-generated local directory").
 		WithMetadata("path", localPath))
 
-	if err := os.MkdirAll(localPath, git.LocalGitOpsDirMode); err != nil {
-		return nil, fmt.Errorf("failed to create auto-generated directory %s: %w", localPath, err)
-	}
-	if err := os.Chmod(localPath, git.LocalGitOpsDirMode); err != nil {
-		return nil, fmt.Errorf("failed to set auto-generated directory permissions %s: %w", localPath, err)
+	if err := git.EnsureLocalGitOpsDir(ctx, localPath); err != nil {
+		return nil, err
 	}
 
 	return gitCfg, nil
@@ -438,6 +434,12 @@ func (c *Client) bootstrapGitOps(ctx context.Context, cfg *config.NebariConfig, 
 		span.RecordError(err)
 		return fmt.Errorf("failed to initialize git repository: %w", err)
 	}
+	if isLocal {
+		if err := gitClient.NormalizeLocalPermissions(ctx); err != nil {
+			span.RecordError(err)
+			return err
+		}
+	}
 
 	// Check if already bootstrapped
 	bootstrapped, err := gitClient.IsBootstrapped(ctx)
@@ -447,12 +449,6 @@ func (c *Client) bootstrapGitOps(ctx context.Context, cfg *config.NebariConfig, 
 	}
 
 	if bootstrapped && !regenApps {
-		if isLocal && cfg.GitRepository == nil {
-			if err := ensureLocalGitOpsPermissions(ctx, localPath); err != nil {
-				span.RecordError(err)
-				return err
-			}
-		}
 		status.Info(ctx, "GitOps repository already bootstrapped, skipping manifest generation")
 		span.SetAttributes(attribute.Bool("skipped", true))
 		return nil
@@ -495,8 +491,8 @@ func (c *Client) bootstrapGitOps(ctx context.Context, cfg *config.NebariConfig, 
 		return fmt.Errorf("failed to commit and push: %w", err)
 	}
 
-	if isLocal && cfg.GitRepository == nil {
-		if err := ensureLocalGitOpsPermissions(ctx, localPath); err != nil {
+	if isLocal {
+		if err := gitClient.NormalizeLocalPermissions(ctx); err != nil {
 			span.RecordError(err)
 			return err
 		}
@@ -537,48 +533,6 @@ func (c *Client) writeConfigToRepo(ctx context.Context, cfg *config.NebariConfig
 	}
 	status.Send(ctx, status.NewUpdate(status.LevelInfo, "Wrote NIC config to repository (auth fields scrubbed)").
 		WithMetadata("path", configDest))
-	return nil
-}
-
-// ensureLocalGitOpsPermissions normalizes NIC-managed local GitOps repositories
-// so ArgoCD's non-root repo-server can read refs and generated manifests through
-// a read-only kind hostPath mount.
-func ensureLocalGitOpsPermissions(ctx context.Context, root string) error {
-	tracer := otel.Tracer("nebari-infrastructure-core")
-	_, span := tracer.Start(ctx, "nic.ensureLocalGitOpsPermissions")
-	defer span.End()
-	span.SetAttributes(attribute.String("local_path", root))
-
-	rootDir, err := os.OpenRoot(root)
-	if err != nil {
-		span.RecordError(err)
-		return fmt.Errorf("open local gitops root %s: %w", root, err)
-	}
-	defer func() {
-		_ = rootDir.Close()
-	}()
-
-	err = fs.WalkDir(rootDir.FS(), ".", func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.Type()&fs.ModeSymlink != 0 {
-			return nil
-		}
-
-		mode := git.LocalGitOpsFileMode
-		if d.IsDir() {
-			mode = git.LocalGitOpsDirMode
-		}
-		if err := rootDir.Chmod(path, mode); err != nil {
-			return fmt.Errorf("set permissions on %s: %w", path, err)
-		}
-		return nil
-	})
-	if err != nil {
-		span.RecordError(err)
-		return fmt.Errorf("set local gitops permissions under %s: %w", root, err)
-	}
 	return nil
 }
 

--- a/pkg/nic/deploy_test.go
+++ b/pkg/nic/deploy_test.go
@@ -12,9 +12,61 @@ import (
 
 	"github.com/nebari-dev/nebari-infrastructure-core/pkg/config"
 	"github.com/nebari-dev/nebari-infrastructure-core/pkg/git"
+	"github.com/nebari-dev/nebari-infrastructure-core/pkg/providers/cluster"
 )
 
-func TestWriteConfigToRepoUsesLocalGitOpsPermissions(t *testing.T) {
+func TestBootstrapGitOpsNormalizesExistingLocalRepository(t *testing.T) {
+	repoPath := t.TempDir()
+	gitConfig := &git.Config{
+		URL:    "file://" + repoPath,
+		Branch: git.DefaultBranch,
+	}
+
+	gitClient, err := git.NewClient(gitConfig)
+	if err != nil {
+		t.Fatalf("NewClient() error: %v", err)
+	}
+	if err := gitClient.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error: %v", err)
+	}
+
+	markerPath := filepath.Join(repoPath, ".bootstrapped")
+	if err := os.WriteFile(markerPath, []byte("bootstrapped_at: test\n"), 0o600); err != nil {
+		t.Fatalf("write bootstrap marker: %v", err)
+	}
+	manifestPath := filepath.Join(repoPath, "application.yaml")
+	if err := os.WriteFile(manifestPath, []byte("kind: Application\n"), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := os.Chmod(repoPath, 0o700); err != nil { //nolint:gosec // Deliberately restrictive setup for permission normalization.
+		t.Fatalf("chmod repository: %v", err)
+	}
+
+	cfg := &config.NebariConfig{
+		ProjectName:   "test",
+		GitRepository: gitConfig,
+	}
+	client := &Client{}
+	if err := client.bootstrapGitOps(context.Background(), cfg, gitConfig, false, cluster.InfraSettings{}, ""); err != nil {
+		t.Fatalf("bootstrapGitOps() error: %v", err)
+	}
+
+	assertMode := func(path string, want os.FileMode) {
+		t.Helper()
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat %s: %v", path, err)
+		}
+		if got := info.Mode().Perm(); got != want {
+			t.Errorf("%s mode = %v, want %v", path, got, want)
+		}
+	}
+	assertMode(repoPath, git.GitOpsDirMode)
+	assertMode(markerPath, git.GitOpsFileMode)
+	assertMode(manifestPath, git.GitOpsFileMode)
+}
+
+func TestWriteConfigToRepoUsesGitOpsPermissions(t *testing.T) {
 	workDir := filepath.Join(t.TempDir(), "gitops")
 	cfg := &config.NebariConfig{ProjectName: "test"}
 	gitConfig := &git.Config{
@@ -31,16 +83,16 @@ func TestWriteConfigToRepoUsesLocalGitOpsPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat workDir: %v", err)
 	}
-	if got := dirInfo.Mode().Perm(); got != git.LocalGitOpsDirMode {
-		t.Errorf("workDir mode = %v, want %v", got, git.LocalGitOpsDirMode)
+	if got := dirInfo.Mode().Perm(); got != git.GitOpsDirMode {
+		t.Errorf("workDir mode = %v, want %v", got, git.GitOpsDirMode)
 	}
 
 	configInfo, err := os.Stat(filepath.Join(workDir, "nic-config.yaml"))
 	if err != nil {
 		t.Fatalf("stat nic-config.yaml: %v", err)
 	}
-	if got := configInfo.Mode().Perm(); got != git.LocalGitOpsFileMode {
-		t.Errorf("nic-config.yaml mode = %v, want %v", got, git.LocalGitOpsFileMode)
+	if got := configInfo.Mode().Perm(); got != git.GitOpsFileMode {
+		t.Errorf("nic-config.yaml mode = %v, want %v", got, git.GitOpsFileMode)
 	}
 }
 

--- a/pkg/nic/deploy_test.go
+++ b/pkg/nic/deploy_test.go
@@ -23,7 +23,7 @@ func TestWriteConfigToRepoUsesLocalGitOpsPermissions(t *testing.T) {
 	}
 
 	client := &Client{}
-	if err := client.writeConfigToRepo(context.Background(), cfg, gitConfig, workDir); err != nil {
+	if err := client.writeConfigToRepo(context.Background(), cfg, gitConfig, workDir, ""); err != nil {
 		t.Fatalf("writeConfigToRepo() error: %v", err)
 	}
 

--- a/pkg/nic/deploy_test.go
+++ b/pkg/nic/deploy_test.go
@@ -12,59 +12,7 @@ import (
 
 	"github.com/nebari-dev/nebari-infrastructure-core/pkg/config"
 	"github.com/nebari-dev/nebari-infrastructure-core/pkg/git"
-	"github.com/nebari-dev/nebari-infrastructure-core/pkg/providers/cluster"
 )
-
-func TestBootstrapGitOpsNormalizesExistingLocalRepository(t *testing.T) {
-	repoPath := t.TempDir()
-	gitConfig := &git.Config{
-		URL:    "file://" + repoPath,
-		Branch: git.DefaultBranch,
-	}
-
-	gitClient, err := git.NewClient(gitConfig)
-	if err != nil {
-		t.Fatalf("NewClient() error: %v", err)
-	}
-	if err := gitClient.Init(context.Background()); err != nil {
-		t.Fatalf("Init() error: %v", err)
-	}
-
-	markerPath := filepath.Join(repoPath, ".bootstrapped")
-	if err := os.WriteFile(markerPath, []byte("bootstrapped_at: test\n"), 0o600); err != nil {
-		t.Fatalf("write bootstrap marker: %v", err)
-	}
-	manifestPath := filepath.Join(repoPath, "application.yaml")
-	if err := os.WriteFile(manifestPath, []byte("kind: Application\n"), 0o600); err != nil {
-		t.Fatalf("write manifest: %v", err)
-	}
-	if err := os.Chmod(repoPath, 0o700); err != nil { //nolint:gosec // Deliberately restrictive setup for permission normalization.
-		t.Fatalf("chmod repository: %v", err)
-	}
-
-	cfg := &config.NebariConfig{
-		ProjectName:   "test",
-		GitRepository: gitConfig,
-	}
-	client := &Client{}
-	if err := client.bootstrapGitOps(context.Background(), cfg, gitConfig, false, cluster.InfraSettings{}, ""); err != nil {
-		t.Fatalf("bootstrapGitOps() error: %v", err)
-	}
-
-	assertMode := func(path string, want os.FileMode) {
-		t.Helper()
-		info, err := os.Stat(path)
-		if err != nil {
-			t.Fatalf("stat %s: %v", path, err)
-		}
-		if got := info.Mode().Perm(); got != want {
-			t.Errorf("%s mode = %v, want %v", path, got, want)
-		}
-	}
-	assertMode(repoPath, git.GitOpsDirMode)
-	assertMode(markerPath, git.GitOpsFileMode)
-	assertMode(manifestPath, git.GitOpsFileMode)
-}
 
 func TestWriteConfigToRepoUsesGitOpsPermissions(t *testing.T) {
 	workDir := filepath.Join(t.TempDir(), "gitops")

--- a/pkg/nic/deploy_test.go
+++ b/pkg/nic/deploy_test.go
@@ -2,6 +2,9 @@ package nic
 
 import (
 	"bytes"
+	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -10,6 +13,36 @@ import (
 	"github.com/nebari-dev/nebari-infrastructure-core/pkg/config"
 	"github.com/nebari-dev/nebari-infrastructure-core/pkg/git"
 )
+
+func TestWriteConfigToRepoUsesLocalGitOpsPermissions(t *testing.T) {
+	workDir := filepath.Join(t.TempDir(), "gitops")
+	cfg := &config.NebariConfig{ProjectName: "test"}
+	gitConfig := &git.Config{
+		URL:    "file:///tmp/test-gitops",
+		Branch: git.DefaultBranch,
+	}
+
+	client := &Client{}
+	if err := client.writeConfigToRepo(context.Background(), cfg, gitConfig, workDir); err != nil {
+		t.Fatalf("writeConfigToRepo() error: %v", err)
+	}
+
+	dirInfo, err := os.Stat(workDir)
+	if err != nil {
+		t.Fatalf("stat workDir: %v", err)
+	}
+	if got := dirInfo.Mode().Perm(); got != git.LocalGitOpsDirMode {
+		t.Errorf("workDir mode = %v, want %v", got, git.LocalGitOpsDirMode)
+	}
+
+	configInfo, err := os.Stat(filepath.Join(workDir, "nic-config.yaml"))
+	if err != nil {
+		t.Fatalf("stat nic-config.yaml: %v", err)
+	}
+	if got := configInfo.Mode().Perm(); got != git.LocalGitOpsFileMode {
+		t.Errorf("nic-config.yaml mode = %v, want %v", got, git.LocalGitOpsFileMode)
+	}
+}
 
 func TestGenerateSecurePassword(t *testing.T) {
 	tests := []struct {

--- a/pkg/nic/destroy.go
+++ b/pkg/nic/destroy.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"os"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -156,7 +157,50 @@ func (c *Client) Destroy(ctx context.Context, cfg *config.NebariConfig, opts Des
 
 	status.Send(ctx, status.NewUpdate(status.LevelSuccess, "Destruction completed successfully").
 		WithMetadata("provider", clusterProvider.Name()))
+
+	if !opts.DryRun {
+		reportRetainedGitOpsDir(ctx, cfg, clusterProvider)
+	}
+
 	return nil
+}
+
+// reportRetainedGitOpsDir logs a reminder that the local GitOps directory is
+// left in place after a destroy so the user knows it exists and where to find
+// it. Cluster teardown does not remove this directory: it may hold local
+// commits or edits the user still wants, and it is cheap to delete manually.
+// Only the NIC-managed local (file://) directory is reported; remote git
+// repositories are the user's to manage. Nothing is logged when the directory
+// no longer exists on disk.
+func reportRetainedGitOpsDir(ctx context.Context, cfg *config.NebariConfig, clusterProvider cluster.Provider) {
+	gitConfig := cfg.GitRepository
+	if gitConfig == nil {
+		// Fall back to the same auto-generated local config deploy uses, but
+		// only for providers that manage a local GitOps directory.
+		if !clusterProvider.InfraSettings(cfg.Cluster).SupportsLocalGitOps {
+			return
+		}
+		gitConfig = defaultGitConfig(cfg.ProjectName)
+	}
+
+	if !gitConfig.IsLocalPath() {
+		return
+	}
+
+	localPath, err := gitConfig.GetLocalPath()
+	if err != nil {
+		return
+	}
+
+	if _, err := os.Stat(localPath); err != nil {
+		// Directory is gone (or unreadable); nothing to remind the user about.
+		return
+	}
+
+	status.Send(ctx, status.NewUpdate(status.LevelInfo,
+		fmt.Sprintf("The local GitOps directory was left in place and can be removed manually: %s", localPath)).
+		WithResource("gitops").
+		WithMetadata("path", localPath))
 }
 
 // destroyDNS removes DNS records associated with the cluster's domain.

--- a/pkg/providers/cluster/local/config.go
+++ b/pkg/providers/cluster/local/config.go
@@ -19,6 +19,8 @@ type KindConfig struct {
 	// ExtraMounts are additional host directories mounted into the cluster
 	// node container. The local file:// gitops repository (explicit or
 	// auto-created) is mounted automatically and does not need to be listed.
+	// Custom mounts are user-managed; NIC does not recursively normalize their
+	// permissions.
 	ExtraMounts []KindMount `yaml:"extra_mounts,omitempty"`
 }
 

--- a/pkg/providers/cluster/local/config.go
+++ b/pkg/providers/cluster/local/config.go
@@ -16,11 +16,11 @@ type KindConfig struct {
 	// Empty means the default image of the bundled kind version.
 	NodeImage string `yaml:"node_image,omitempty"`
 
-	// ExtraMounts are additional host directories mounted into the cluster
-	// node container. The local file:// gitops repository (explicit or
-	// auto-created) is mounted automatically and does not need to be listed.
-	// Custom mounts are user-managed; NIC does not recursively normalize their
-	// permissions.
+	// ExtraMounts are additional host directories mounted into the cluster node
+	// container. NIC mounts its auto-created local GitOps repository
+	// automatically; an explicit file:// repository needs a matching entry here.
+	// Other custom mounts are user-managed, and NIC does not recursively
+	// normalize their permissions.
 	ExtraMounts []KindMount `yaml:"extra_mounts,omitempty"`
 }
 

--- a/pkg/providers/cluster/local/kind.go
+++ b/pkg/providers/cluster/local/kind.go
@@ -74,13 +74,9 @@ func createKindCluster(ctx context.Context, kp *cluster.Provider, name string, k
 	// host path to exist when the cluster is created, so it gets created here if it
 	// does not exist already
 	defaultGitOps := git.DefaultLocalPath(name)
-	if err := os.MkdirAll(defaultGitOps, git.LocalGitOpsDirMode); err != nil {
+	if err := git.EnsureLocalGitOpsDir(ctx, defaultGitOps); err != nil {
 		span.RecordError(err)
-		return fmt.Errorf("create local gitops directory %s: %w", defaultGitOps, err)
-	}
-	if err := os.Chmod(defaultGitOps, git.LocalGitOpsDirMode); err != nil {
-		span.RecordError(err)
-		return fmt.Errorf("set local gitops directory permissions %s: %w", defaultGitOps, err)
+		return err
 	}
 	mounts = append(mounts, v1alpha4.Mount{
 		HostPath:      defaultGitOps,
@@ -89,6 +85,8 @@ func createKindCluster(ctx context.Context, kp *cluster.Provider, name string, k
 	})
 
 	for _, m := range kindCfg.ExtraMounts {
+		// Custom mounts are user-managed. NIC creates the host path if needed
+		// for kind, but does not recursively normalize existing permissions.
 		if err := os.MkdirAll(m.HostPath, git.LocalGitOpsDirMode); err != nil {
 			span.RecordError(err)
 			return fmt.Errorf("create extra_mount host path %s: %w", m.HostPath, err)

--- a/pkg/providers/cluster/local/kind.go
+++ b/pkg/providers/cluster/local/kind.go
@@ -74,11 +74,11 @@ func createKindCluster(ctx context.Context, kp *cluster.Provider, name string, k
 	// host path to exist when the cluster is created, so it gets created here if it
 	// does not exist already
 	defaultGitOps := git.DefaultLocalPath(name)
-	if err := os.MkdirAll(defaultGitOps, git.LocalGitOpsDirMode); err != nil { //nolint:gosec // Local GitOps repo must be readable by ArgoCD's non-root repo-server.
+	if err := os.MkdirAll(defaultGitOps, git.LocalGitOpsDirMode); err != nil {
 		span.RecordError(err)
 		return fmt.Errorf("create local gitops directory %s: %w", defaultGitOps, err)
 	}
-	if err := os.Chmod(defaultGitOps, git.LocalGitOpsDirMode); err != nil { //nolint:gosec // Local GitOps repo must be readable by ArgoCD's non-root repo-server.
+	if err := os.Chmod(defaultGitOps, git.LocalGitOpsDirMode); err != nil {
 		span.RecordError(err)
 		return fmt.Errorf("set local gitops directory permissions %s: %w", defaultGitOps, err)
 	}
@@ -89,7 +89,7 @@ func createKindCluster(ctx context.Context, kp *cluster.Provider, name string, k
 	})
 
 	for _, m := range kindCfg.ExtraMounts {
-		if err := os.MkdirAll(m.HostPath, git.LocalGitOpsDirMode); err != nil { //nolint:gosec // Missing kind hostPath directories must be pod-readable when mounted.
+		if err := os.MkdirAll(m.HostPath, git.LocalGitOpsDirMode); err != nil {
 			span.RecordError(err)
 			return fmt.Errorf("create extra_mount host path %s: %w", m.HostPath, err)
 		}

--- a/pkg/providers/cluster/local/kind.go
+++ b/pkg/providers/cluster/local/kind.go
@@ -74,9 +74,13 @@ func createKindCluster(ctx context.Context, kp *cluster.Provider, name string, k
 	// host path to exist when the cluster is created, so it gets created here if it
 	// does not exist already
 	defaultGitOps := git.DefaultLocalPath(name)
-	if err := os.MkdirAll(defaultGitOps, 0o750); err != nil {
+	if err := os.MkdirAll(defaultGitOps, git.LocalGitOpsDirMode); err != nil { //nolint:gosec // Local GitOps repo must be readable by ArgoCD's non-root repo-server.
 		span.RecordError(err)
 		return fmt.Errorf("create local gitops directory %s: %w", defaultGitOps, err)
+	}
+	if err := os.Chmod(defaultGitOps, git.LocalGitOpsDirMode); err != nil { //nolint:gosec // Local GitOps repo must be readable by ArgoCD's non-root repo-server.
+		span.RecordError(err)
+		return fmt.Errorf("set local gitops directory permissions %s: %w", defaultGitOps, err)
 	}
 	mounts = append(mounts, v1alpha4.Mount{
 		HostPath:      defaultGitOps,
@@ -85,7 +89,7 @@ func createKindCluster(ctx context.Context, kp *cluster.Provider, name string, k
 	})
 
 	for _, m := range kindCfg.ExtraMounts {
-		if err := os.MkdirAll(m.HostPath, 0o750); err != nil {
+		if err := os.MkdirAll(m.HostPath, git.LocalGitOpsDirMode); err != nil { //nolint:gosec // Missing kind hostPath directories must be pod-readable when mounted.
 			span.RecordError(err)
 			return fmt.Errorf("create extra_mount host path %s: %w", m.HostPath, err)
 		}

--- a/pkg/providers/cluster/local/kind.go
+++ b/pkg/providers/cluster/local/kind.go
@@ -85,9 +85,9 @@ func createKindCluster(ctx context.Context, kp *cluster.Provider, name string, k
 	})
 
 	for _, m := range kindCfg.ExtraMounts {
-		// Custom mounts are user-managed. NIC creates the host path if needed
-		// for kind, but does not recursively normalize existing permissions.
-		if err := os.MkdirAll(m.HostPath, git.LocalGitOpsDirMode); err != nil {
+		// Create custom mount roots for kind without changing existing contents.
+		// GitOps bootstrap separately normalizes a configured file:// repository.
+		if err := os.MkdirAll(m.HostPath, 0o750); err != nil {
 			span.RecordError(err)
 			return fmt.Errorf("create extra_mount host path %s: %w", m.HostPath, err)
 		}

--- a/pkg/providers/cluster/local/provider.go
+++ b/pkg/providers/cluster/local/provider.go
@@ -147,7 +147,7 @@ func (p *Provider) Deploy(ctx context.Context, projectName string, clusterConfig
 		return err
 	}
 	if exists {
-		status.Send(ctx, status.NewUpdate(status.LevelInfo, fmt.Sprintf("Kind cluster %s already exists, reusing it (changes to kind settings such as node_image or extra_mounts only take effect on a recreate)", projectName)).
+		status.Send(ctx, status.NewUpdate(status.LevelInfo, fmt.Sprintf("Kind cluster %s already exists, reusing it (changes to kind settings such as node_image, extra_mounts, or the default local GitOps mount path only take effect on a recreate)", projectName)).
 			WithResource("provider").
 			WithAction("deploy").
 			WithMetadata("cluster_name", projectName))


### PR DESCRIPTION
## Closes

<!-- Link to issue(s) this PR addresses, e.g., Closes #123 -->

## Description

I was running into issues getting the cluster to come up locally with `./nic deploy -f examples/local-config.yaml` on mac.

This PR 
- changes the local gitops dir path to ~/.nic/gitops/<project> (this may not strictly be necessary but keeps the path consistent cross platform and in a stable non-tmp location. Happy to drop this change or move the dir somewhere else) see https://github.com/golang/go/issues/21318 and https://github.com/nebari-dev/nebari-infrastructure-core/issues/374
- fixes file permissions on the dir and files so that non-root argo containers can read them
- logs a message on destroy that local gitops repo will remain on disk

## How to Test


```
./nic destroy -f examples/local-config.yaml
./nic deploy -f examples/local-config.yaml

ls -l ~/.nic/gitops/<project> 

```

On destroy nic logs about the remaining local gitops dir if present

```
./nic destroy -f examples/local-config.yaml
...
"The local GitOps directory was left in place and can be removed manually: /Users/jameswork/.nic/gitops/my-nebari-local","resource":"gitops","path":"/Users/jameswork/.nic/gitops/my-nebari-local"
```

Re-deploying with an existing local gitops dir works as expected

```
ls -l ~/.nic/gitops/<project> 

drwxr-xr-x@ 16 jameswork  staff  512 Jul 10 12:23 apps
drwxr-xr-x@  7 jameswork  staff  224 Jul 10 12:23 manifests
-rw-r--r--@  1 jameswork  staff  471 Jul 10 12:23 nic-config.yaml

./nic deploy -f examples/local-config.yaml

<success>
```

Argo can read future writes to the gitops dir by default

```
echo 'test123' >~/.nic/gitops/my-nebari-local/test.txt
kubectl exec -n argocd argocd-repo-server-768b5c5f68-kt6tg -- cat /Users/jameswork/.nic/gitops/my-nebari-local/test.txt

test123
```

You should see the cluster come up and not hang on provisioning a load balancer.
`kubectl get pods -n envoy-gateway-system` shows healthy pods