### PR TITLE
docs: mock TLS-inspecting proxy verification recipe + script (#312)

### DIFF
--- a/docs/verify-tls-proxy.md
+++ b/docs/verify-tls-proxy.md
@@ -1,0 +1,75 @@
+# Verifying enterprise CA-bundle propagation against a mock TLS-inspecting proxy
+
+This is the developer recipe for issue #312 (child of the enterprise CA-bundle
+epic #307). It lets you confirm, locally and without a corporate sandbox, that
+a cluster deployed with `trust_bundle` actually trusts an org CA end-to-end when
+all egress is intercepted by a TLS-inspecting proxy.
+
+The idea: run [mitmproxy](https://mitmproxy.org/) as an egress proxy that
+re-signs every upstream certificate with a throwaway "org CA", deploy a cluster
+that trusts that CA via `trust_bundle`, then drive outbound HTTPS from the
+affected components through the proxy and assert it succeeds.
+
+## Prerequisites
+
+- Docker, `kubectl`, `openssl`.
+- A local cluster (kind or k3d) whose node(s) sit on a docker network. Find the
+  network name with `docker inspect <node-container> --format '{{range $k,$v := .NetworkSettings.Networks}}{{$k}}{{end}}'` (kind: `kind`; k3d: `k3d-<clustername>`).
+
+## Recipe
+
+1. **Generate a throwaway org CA:**
+
+   ```bash
+   scripts/verify-tls-proxy.sh --gen-ca /tmp/mockca
+   # prints /tmp/mockca/org-ca.crt (deploy with this) and org-ca.key (verify with this)
+   ```
+
+2. **Deploy the cluster trusting that CA.** Point `trust_bundle` at the cert and
+   deploy as usual:
+
+   ```yaml
+   trust_bundle:
+     path: /tmp/mockca/org-ca.crt
+   ```
+
+   This propagates the org CA to the worker-node trust store (AWS), and — once
+   the foundational apps sync — to the ArgoCD repo-server (#353) and Keycloak
+   (#350) via trust-manager's projected `nebari-trust-bundle` (#346).
+
+3. **Run the verification:**
+
+   ```bash
+   scripts/verify-tls-proxy.sh \
+     --kubeconfig ~/.kube/config \
+     --docker-network k3d-mycluster \
+     --ca-cert /tmp/mockca/org-ca.crt \
+     --ca-key  /tmp/mockca/org-ca.key
+   ```
+
+   The script starts mitmproxy on the cluster's docker network signing with the
+   org CA, then from the repo-server it:
+   - clones an HTTPS git repo through the proxy using the propagated bundle and
+     asserts **success**, and
+   - repeats the clone forced onto the system-only CA bundle and asserts
+     **failure** (`x509: certificate signed by unknown authority`).
+
+   The negative control matters: it proves the success is due to the injected
+   org CA, not to the target happening to be reachable another way.
+
+## Extending to other components
+
+The same proxy works for any in-cluster client — point it at
+`http://<proxy-ip>:8080`. For example, to check Keycloak's outbound trust
+(#311/#350), exec the Keycloak pod and run an HTTPS request through the proxy
+using its truststore. The repo-server case is scripted here because it is the
+clearest DoD (#310/#353); the others are left as manual `kubectl exec` checks
+for now.
+
+## CI
+
+Deferred, deliberately. This harness needs Docker (to run mitmproxy on the
+cluster's docker network) plus a live kind/k3d cluster deployed with
+`trust_bundle`, which is heavier than the current unit/template test tiers. Run
+it locally or in a nightly/optional job rather than on every PR. Revisit if the
+CA-bundle stack starts regressing.

--- a/scripts/verify-tls-proxy.sh
+++ b/scripts/verify-tls-proxy.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Verify enterprise CA-bundle propagation against a mock TLS-inspecting proxy.
+#
+# Implements the verification recipe for issue #312 (child of the enterprise
+# CA-bundle epic #307). It stands up mitmproxy as a TLS-inspecting egress proxy
+# that re-signs every upstream certificate with a throwaway "org CA", then
+# drives an outbound HTTPS clone from the ArgoCD repo-server through it and
+# asserts that:
+#
+#   1. WITH the propagated bundle (SSL_CERT_FILE/GIT_SSL_CAINFO set by the
+#      trust_bundle feature) the clone SUCCEEDS, and
+#   2. WITHOUT it (system CAs only) the clone FAILS with an unknown-authority
+#      error -- proving the success in (1) is due to the injected org CA and
+#      not something else.
+#
+# Prerequisite: a running cluster (kind or k3d) whose node(s) sit on a docker
+# network, already deployed with `trust_bundle` pointing at the CA certificate
+# this script uses (see --ca-cert / --gen-ca and docs/verify-tls-proxy.md).
+#
+# This harness covers the repo-server (the clearest DoD, per #310/#353). Other
+# components (Keycloak outbound, user pods) can be exercised with the same
+# proxy by pointing their client at http://<proxy-ip>:8080; see the docs.
+set -euo pipefail
+
+KUBECONFIG_PATH="${KUBECONFIG:-}"
+DOCKER_NETWORK=""
+CA_CERT=""
+CA_KEY=""
+GEN_CA=""
+TARGET_URL="https://github.com/argoproj/argo-cd"
+PROXY_NAME="nic-tls-proxy-verify"
+PROXY_PORT="8080"
+
+usage() {
+  cat <<EOF
+Usage: $0 --kubeconfig PATH --docker-network NAME [--ca-cert FILE --ca-key FILE | --gen-ca DIR] [--target-url URL]
+
+  --kubeconfig       kubeconfig for the target cluster (or set KUBECONFIG)
+  --docker-network   docker network the cluster node(s) are attached to
+                     (kind: 'kind'; k3d: 'k3d-<clustername>')
+  --ca-cert/--ca-key PEM cert + key of the org CA the cluster was deployed to
+                     trust (trust_bundle). The proxy signs with this.
+  --gen-ca DIR       instead of --ca-cert/--ca-key, generate a throwaway org CA
+                     into DIR (org-ca.crt/org-ca.key) and print the cert path
+                     to deploy with, then exit (run again with --ca-cert/key).
+  --target-url       HTTPS git URL to clone through the proxy (default: $TARGET_URL)
+EOF
+  exit "${1:-0}"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --kubeconfig) KUBECONFIG_PATH="$2"; shift 2;;
+    --docker-network) DOCKER_NETWORK="$2"; shift 2;;
+    --ca-cert) CA_CERT="$2"; shift 2;;
+    --ca-key) CA_KEY="$2"; shift 2;;
+    --gen-ca) GEN_CA="$2"; shift 2;;
+    --target-url) TARGET_URL="$2"; shift 2;;
+    -h|--help) usage 0;;
+    *) echo "unknown arg: $1" >&2; usage 1;;
+  esac
+done
+
+if [ -n "$GEN_CA" ]; then
+  mkdir -p "$GEN_CA"
+  openssl req -x509 -newkey rsa:2048 -nodes \
+    -keyout "$GEN_CA/org-ca.key" -out "$GEN_CA/org-ca.crt" \
+    -days 3650 -subj "/CN=Mock Org CA - nic tls-proxy verify" >/dev/null 2>&1
+  echo "Generated throwaway org CA:"
+  echo "  cert: $GEN_CA/org-ca.crt   (set trust_bundle.path to this and deploy)"
+  echo "  key : $GEN_CA/org-ca.key   (pass both back via --ca-cert/--ca-key to verify)"
+  exit 0
+fi
+
+[ -n "$KUBECONFIG_PATH" ] || { echo "ERROR: --kubeconfig required" >&2; usage 1; }
+[ -n "$DOCKER_NETWORK" ] || { echo "ERROR: --docker-network required" >&2; usage 1; }
+[ -n "$CA_CERT" ] && [ -n "$CA_KEY" ] || { echo "ERROR: --ca-cert and --ca-key required (or use --gen-ca)" >&2; usage 1; }
+
+KUBECTL="kubectl --kubeconfig $KUBECONFIG_PATH"
+
+cleanup() { docker rm -f "$PROXY_NAME" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+echo "==> Building mitmproxy CA from the org CA and starting the proxy"
+CONF="$(mktemp -d)"
+cat "$CA_KEY" "$CA_CERT" > "$CONF/mitmproxy-ca.pem"
+chmod -R a+rX "$CONF"
+cleanup
+docker run -d --name "$PROXY_NAME" --network "$DOCKER_NETWORK" \
+  -v "$CONF:/home/mitmproxy/.mitmproxy" \
+  mitmproxy/mitmproxy mitmdump --listen-port "$PROXY_PORT" \
+  --set confdir=/home/mitmproxy/.mitmproxy >/dev/null
+sleep 4
+PROXY_IP="$(docker inspect "$PROXY_NAME" --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')"
+[ -n "$PROXY_IP" ] || { echo "ERROR: could not determine proxy IP on $DOCKER_NETWORK" >&2; exit 1; }
+echo "    proxy at $PROXY_IP:$PROXY_PORT (signing with $(openssl x509 -in "$CA_CERT" -noout -subject))"
+
+RS="$($KUBECTL -n argocd get pod -l app.kubernetes.io/name=argocd-repo-server -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+[ -n "$RS" ] || { echo "ERROR: no argocd repo-server pod found" >&2; exit 1; }
+echo "==> repo-server: $RS"
+
+echo "==> [1/2] clone through the proxy using the propagated bundle (expect SUCCESS)"
+if $KUBECTL -n argocd exec "$RS" -c repo-server -- sh -c \
+     "export https_proxy=http://$PROXY_IP:$PROXY_PORT HTTPS_PROXY=http://$PROXY_IP:$PROXY_PORT; git ls-remote $TARGET_URL HEAD" >/dev/null 2>&1; then
+  echo "    PASS: clone succeeded (org CA is trusted via the propagated bundle)"
+else
+  echo "    FAIL: clone failed WITH the propagated bundle -- trust_bundle not wired?" >&2
+  exit 1
+fi
+
+echo "==> [2/2] control: same clone forced onto the system-only bundle (expect FAILURE)"
+if $KUBECTL -n argocd exec "$RS" -c repo-server -- sh -c \
+     "export https_proxy=http://$PROXY_IP:$PROXY_PORT HTTPS_PROXY=http://$PROXY_IP:$PROXY_PORT GIT_SSL_CAINFO=/etc/ssl/certs/ca-certificates.crt; git ls-remote $TARGET_URL HEAD" >/dev/null 2>&1; then
+  echo "    FAIL: clone unexpectedly succeeded with the system-only bundle -- control is invalid" >&2
+  exit 1
+else
+  echo "    PASS: clone failed as expected (system bundle does not trust the org CA)"
+fi
+
+echo "==> OK: CA-bundle propagation verified end-to-end against the mock proxy"


### PR DESCRIPTION
Closes #312.

Adds a scripted + documented way to verify the enterprise CA-bundle propagation (epic #307) locally against a mock TLS-inspecting proxy, without standing up a corporate sandbox.

`scripts/verify-tls-proxy.sh` runs mitmproxy as an egress proxy that re-signs upstream certs with a throwaway org CA, then from the ArgoCD repo-server:
- clones an HTTPS repo through the proxy using the propagated bundle and asserts **success**,
- repeats the clone forced onto the system-only bundle and asserts **failure** (`x509: certificate signed by unknown authority`).

The negative control is the point: it proves the success is the injected org CA, not the target being reachable some other way. This is the same recipe I used to validate #353 by hand.

`docs/verify-tls-proxy.md` documents the full flow: generate a throwaway CA (`--gen-ca`), deploy with `trust_bundle` pointing at it, then run the script.

Scope and notes:
- Covers the repo-server (the clearest DoD, per #310/#353). Keycloak and user-pod checks are documented as manual `kubectl exec` through the same proxy rather than scripted, for now.
- The doc lives at `docs/verify-tls-proxy.md` (flat), matching the existing `docs/custom-tls-certificate.md` convention rather than the `docs/operations/` path the issue suggested (there's no such dir today). Easy to move if we want that layout.
- CI: deferred deliberately, per the issue's "explicit decision to defer" option. It needs Docker plus a live kind/k3d cluster deployed with `trust_bundle`, which is heavier than the current unit/template tiers. Better as a nightly/optional job than per-PR. Rationale is in the doc.

Works against kind or k3d (any cluster whose node(s) are on a docker network).
